### PR TITLE
start_date and end_date casting fix

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -143,8 +143,8 @@ joined as (
 bounded as (
     select 
         *,
-        {% if start_date %} '{{ start_date }}' {% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
-        {% if end_date %} '{{ end_date }}' {% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
+        {% if start_date %}cast('{{ start_date }}' as date){% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
+        {% if end_date %}cast('{{ end_date }}' as date){% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
     from joined 
 ),
 


### PR DESCRIPTION
## Description of the changes
As discussed within Issue https://github.com/dbt-labs/dbt_metrics/issues/20. This PR explicitly casts the arguments for `start_date` and `end_date` as dates. On my local branch, when this was not applied I received a `no matching signature` error in a downstream where clause.

## How were the changes tests
I tested this locally on my branch and was able to see the issue be resolved. It is strange that this was only happening on my local machine, but not on others. I wonder if this is a warehouse specific issue that I was experiencing on BigQuery. Regardless, with this update the issue didn't persist for me. Happy to discuss this in more detail if you would like!

## Signed Individual Contributor Agreement?
- [x] Yes

## Additional Context
Let me know if you would like me to update a CHANGELOG or make any other adjustments to this branch before merging. Thanks!

