### PR TITLE
Allow start/end dates in metrics to be simple strings and function calls

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -145,12 +145,10 @@ joined as (
 bounded as (
     select 
         *,
-        /* assume any start_date that is defined and contains an opening parentheses is likely a function call and the implementor is smart enough to use a function that returns a date */
-        {% if '(' in start_date %} {{ start_date }}
+        {% if '(' in start_date %} /* assume any start_date that is defined and contains an opening parentheses is likely a function call and does not need to be quoted */ cast({{ start_date }} as date)
         {% elif start_date %} cast('{{ start_date }}' as date)
         {% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
-        /* assume any end_date that is defined and contains an opening parentheses is likely a function call and the implementor is smart enough to use a function that returns a date */
-        {% if '(' in end_date %} {{ end_date }}
+        {% if '(' in end_date %} /* assume any end_date that is defined and contains an opening parentheses is likely a function call and does not need to be quoted */ cast({{ end_date }} as date)
         {% elif end_date %} cast('{{ end_date }}' as date)
         {% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
     from joined 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -145,8 +145,8 @@ joined as (
 bounded as (
     select 
         *,
-        {% if start_date %}'{{ start_date }}'{% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
-        {% if end_date %}'{{ end_date }}'{% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
+        {% if start_date %} {{ start_date }} {% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
+        {% if end_date %} {{ end_date }} {% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
     from joined 
 ),
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -145,8 +145,8 @@ joined as (
 bounded as (
     select 
         *,
-        {% if start_date %}cast('{{ start_date }}' as date){% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
-        {% if end_date %}cast('{{ end_date }}' as date){% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
+        {% if start_date %}'{{ start_date }}'{% else %} min(case when has_data then period end) over () {% endif %} as lower_bound,
+        {% if end_date %}'{{ end_date }}'{% else %} max(case when has_data then period end) over () {% endif %} as upper_bound
     from joined 
 ),
 


### PR DESCRIPTION
## Description of the changes
As discussed within Issue #27. This PR dynamically detects the contents in `start_date` and `end_date` and decides if it needs to wrap the user input in single quotes.
- If `start_date` contains a function call, then leave it un-quoted so the call will be executed
  - compiled unquoted SQL: `cast('dateadd(day, -1, date_trunc("day", getdate()))' as date) as upper_bound` 
- Else if `state_date` contains only a basic date string, wrap it in quotes
  - compiled qutoed SQL: `cast('202201-01' as date) as upper_bound`
- Else act like `start_date` isn't defined
  - compiled SQL existing else-block: `max(case when has_data then period end) over () {% endif %} as upper_bound` 

## How were the changes tests
I tested this locally on my branch using a mix of simple strings and function calls for `start_date` and `end_date`. I then `select * from metric;` on a Snowflake table and view. 

## Signed Individual Contributor Agreement?
* [x]  Yes

## Additional Context
### Possible improvements
- Better detection of "is a function call being used?" Currently I just look for `(` since most databases I have used call functions like `get_date()`

