### PR TITLE
Removing Cartesian Join

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -71,7 +71,7 @@ with source_query as (
     {%- endfor %}
 ),
 
- spine__time as (
+spine__time as (
      select 
         /* this could be the same as date_day if grain is day. That's OK! 
         They're used for different things: date_day for joining to the spine, period for aggregating.*/
@@ -84,32 +84,29 @@ with source_query as (
         {% endfor %}
         date_day
      from {{ calendar_tbl }}
- ),
 
-{%- for dim in dimensions -%}
-    {%- if metrics.is_dim_from_model(metric, dim) %}
-          
-        spine__values__{{ dim }} as (
+),
 
-            select distinct {{ dim }}
-            from source_query
+spine__values as (
 
-        ),  
-    {% endif -%}
+    {#- /*On  
+    it's unnecessary to pull through the whole table */ #}
+    select distinct 
+        {%- for dim in dimensions -%}
+            {%- if metrics.is_dim_from_model(metric, dim) %}
+                {{ dim }}
+                {% if not loop.last %},{% endif %}
+            {% endif -%}
+        {%- endfor %}
+    from source_query
 
-
-{%- endfor %}
+),  
 
 spine as (
 
     select *
     from spine__time
-    {%- for dim in dimensions -%}
-
-        {%- if metrics.is_dim_from_model(metric, dim) %}
-            cross join spine__values__{{ dim }}
-        {%- endif %}
-    {%- endfor %}
+    cross join spine__values
 
 ),
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -87,9 +87,10 @@ spine__time as (
 
 ),
 
+{% if dimensions is defined and dimensions|length > 0 %}
 spine__values as (
 
-    {#- /*This and the follwoing CTEs were changed on 5/20 in order to remove 
+    {#- /*This and the following CTEs were changed on 5/20 in order to remove 
     the cartesian join behaviour that resulted in impossible combinations of 
     data. */ #}
     select distinct 
@@ -102,12 +103,16 @@ spine__values as (
     from source_query
 
 ),  
+{% endif -%}
+
 
 spine as (
 
     select *
     from spine__time
+    {% if dimensions is defined and dimensions|length > 0 %}
     cross join spine__values
+    {% endif -%}
 
 ),
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -89,8 +89,9 @@ spine__time as (
 
 spine__values as (
 
-    {#- /*On  
-    it's unnecessary to pull through the whole table */ #}
+    {#- /*This and the follwoing CTEs were changed on 5/20 in order to remove 
+    the cartesian join behaviour that resulted in impossible combinations of 
+    data. */ #}
     select distinct 
         {%- for dim in dimensions -%}
             {%- if metrics.is_dim_from_model(metric, dim) %}


### PR DESCRIPTION
## Removing Cartesian Join
Issue: #9 

### What Does This PR Do?
This PR changes the `get_metric_sql` macro to remove the cartesian join in the `spine__values` and `spine` CTE's. 

- Current Behavior: Combinations of data that do not exist within the parent dataset are reflected in the dataset produced by the macro. See Issue #9 for example.
- New Behavior: `spine__values` now selects distinct combinations of all provided dimensions and then creates the `spine` CTE with that list of combinations.

### Should This PR Be Merged?
It really depends on how strongly we feel about the cartesian join functionality. I'm unsure of what use case there would be for impossible combinations of dimensions but @joellabes has thought about this more than I have and has stated that there is a use case.

As such, I'm opening this PR and will keep it open until we can come to a community/internal determination of whether we want to support this use case! The main difference between this and my last PR is that I removed the parameter within the metrics macro. My personal opinion is that we either remove that functionality or keep it within the package - too many parameters makes writing the macro `not fun`. 

