### PR TITLE
Renaming To Calculate

### DIFF
--- a/integration_tests/models/metric_testing_models/base_average_metric.sql
+++ b/integration_tests/models/metric_testing_models/base_average_metric.sql
@@ -1,6 +1,6 @@
 select *
 from 
-{{ metrics.metric(metric('base_average_metric'), 
+{{ metrics.calculate(metric('base_average_metric'), 
     grain='day', 
     dimensions=['had_discount']) 
 }}

--- a/integration_tests/models/metric_testing_models/base_count_metric__no_end_date.sql
+++ b/integration_tests/models/metric_testing_models/base_count_metric__no_end_date.sql
@@ -1,6 +1,6 @@
 select *
 from 
-{{ metrics.metric(
+{{ metrics.calculate(
     metric('base_count_metric'), 
     grain='month', 
     dimensions=['has_messaged','is_active_past_quarter'], 

--- a/integration_tests/models/metric_testing_models/base_count_metric__no_start_date.sql
+++ b/integration_tests/models/metric_testing_models/base_count_metric__no_start_date.sql
@@ -1,6 +1,7 @@
 select *
 from 
-{{ metrics.metric(metric('base_count_metric'), 
+{{ metrics.calculate(
+    metric('base_count_metric'), 
     grain='month', 
     dimensions=['has_messaged','is_active_past_quarter'], 
     end_date = '2021-03-01'

--- a/integration_tests/models/metric_testing_models/base_count_metric__secondary_calculations.sql
+++ b/integration_tests/models/metric_testing_models/base_count_metric__secondary_calculations.sql
@@ -1,6 +1,7 @@
 select *
 from 
-{{ metrics.metric(metric('base_count_metric'), 
+{{ metrics.calculate(
+    metric('base_count_metric'), 
     grain='month', 
     dimensions=['has_messaged','is_active_past_quarter'], 
     start_date = '2021-01-01',

--- a/integration_tests/models/metric_testing_models/base_sum_metric.sql
+++ b/integration_tests/models/metric_testing_models/base_sum_metric.sql
@@ -1,6 +1,7 @@
 select *
 from 
-{{ metrics.metric(metric('base_sum_metric'), 
+{{ metrics.calculate(
+    metric('base_sum_metric'), 
     grain='day', 
     dimensions=['had_discount']) 
 }}

--- a/integration_tests/models/metric_testing_models/expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/expression_metric.sql
@@ -1,6 +1,7 @@
 select *
 from 
-{{ metrics.metric(metric('expression_metric'), 
+{{ metrics.calculate(
+    metric('expression_metric'), 
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',

--- a/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
@@ -1,6 +1,7 @@
 select *
 from 
-{{ metrics.metric(metric('metric_on_expression_metric'), 
+{{ metrics.calculate(
+    metric('metric_on_expression_metric'), 
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',

--- a/integration_tests/models/metric_testing_models/multiple_metrics__base_metrics.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__base_metrics.sql
@@ -1,6 +1,6 @@
 select *
 from 
-{{ metrics.metric(
+{{ metrics.calculate(
     [metric('base_sum_metric'), metric('base_average_metric')], 
     grain='day', 
     dimensions=['had_discount']) 

--- a/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
@@ -1,7 +1,7 @@
 with metric as (
   select *
   from 
-  {{ metrics.metric(
+  {{ metrics.calculate(
       [metric('base_sum_metric'), metric('base_average_metric')], 
       grain='day', 
       dimensions=['had_discount'], 

--- a/integration_tests/models/metric_testing_models/multiple_metrics__period_to_date.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__period_to_date.sql
@@ -1,6 +1,6 @@
 select *
 from 
-{{ metrics.metric(
+{{ metrics.calculate(
     [metric('base_sum_metric'), metric('base_average_metric')], 
     grain='day', 
     dimensions=['had_discount'], 

--- a/integration_tests/models/metric_testing_models/multiple_metrics__rolling.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__rolling.sql
@@ -1,6 +1,6 @@
 select *
 from 
-{{ metrics.metric(
+{{ metrics.calculate(
     [metric('base_sum_metric'), metric('base_average_metric')], 
     grain='day', 
     dimensions=['had_discount'], 

--- a/macros/metric.sql
+++ b/macros/metric.sql
@@ -1,9 +1,9 @@
-{% macro metric(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
-    {{ return(adapter.dispatch('metric', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
+{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
+    {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
 {% endmacro %}
 
 
-{% macro default__metric(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
+{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 


### PR DESCRIPTION
Based on some great feedback from the developer experience team, we renamed the `metric` macro to `calculate`. Then we updated the integration testing.