### PR TITLE
Updating Tree Logic

### DIFF
--- a/.github/actions/end-to-end-test/action.yml
+++ b/.github/actions/end-to-end-test/action.yml
@@ -33,5 +33,5 @@ runs:
       run: |
         cd ${{ inputs.dbt-project }}
         dbt deps --target ${{ inputs.dbt-target }}
-        dbt seed --target ${{ inputs.dbt-target }}
+        dbt seed --target ${{ inputs.dbt-target }} --full-refresh
         dbt build --target ${{ inputs.dbt-target }} --full-refresh

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/dbt-labs/dbt-redshift.git
 git+https://github.com/dbt-labs/dbt-snowflake.git
 git+https://github.com/dbt-labs/dbt-bigquery.git
-git+https://github.com/dbt-labs/dbt-core.git==1.2.0rc1
+git+https://github.com/dbt-labs/dbt-core.git@0db634d

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dbt-labs/dbt-redshift.git
-git+https://github.com/dbt-labs/dbt-snowflake.git
-git+https://github.com/dbt-labs/dbt-bigquery.git
+git+https://github.com/dbt-labs/dbt-redshift.git@1.2.0rc1
+git+https://github.com/dbt-labs/dbt-snowflake.git@1.2.0rc1
+git+https://github.com/dbt-labs/dbt-bigquery.git@1.2.0rc1
 git+https://github.com/dbt-labs/dbt-core.git@0db634d#egg=dbt-core&subdirectory=core

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/dbt-labs/dbt-redshift.git
 git+https://github.com/dbt-labs/dbt-snowflake.git
 git+https://github.com/dbt-labs/dbt-bigquery.git
-git+https://github.com/dbt-labs/dbt-core.git@0db634d
+git+https://github.com/dbt-labs/dbt-core.git@0db634d#egg=dbt-core&subdirectory=core

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/dbt-labs/dbt-redshift.git
 git+https://github.com/dbt-labs/dbt-snowflake.git
 git+https://github.com/dbt-labs/dbt-bigquery.git
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git==1.2.0rc1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dbt-labs/dbt-redshift.git@1.2.0rc1
-git+https://github.com/dbt-labs/dbt-snowflake.git@1.2.0rc1
-git+https://github.com/dbt-labs/dbt-bigquery.git@1.2.0rc1
+git+https://github.com/dbt-labs/dbt-redshift.git@c35865b
+git+https://github.com/dbt-labs/dbt-snowflake.git@a017382
+git+https://github.com/dbt-labs/dbt-bigquery.git@d52222e
 git+https://github.com/dbt-labs/dbt-core.git@0db634d#egg=dbt-core&subdirectory=core

--- a/integration_tests/models/metric_testing_models/multiple_metrics__expression_metrics.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__expression_metrics.sql
@@ -1,0 +1,7 @@
+select *
+from 
+{{ metrics.calculate(
+    [metric('expression_metric'), metric('metric_on_expression_metric')], 
+    grain='day', 
+    dimensions=['had_discount']) 
+}}

--- a/integration_tests/seeds/expected/base_count_metric__secondary_calculations_expected.csv
+++ b/integration_tests/seeds/expected/base_count_metric__secondary_calculations_expected.csv
@@ -1,4 +1,4 @@
-﻿date_month,date_year,has_messaged,is_active_past_quarter,base_count_metric,pop_1mth,ratio_to_1_month_ago,ytd_sum,max_for_month,avg_3mth,rolling_sum_3_month
+﻿date_month,date_year,has_messaged,is_active_past_quarter,base_count_metric,base_count_metric_pop_1mth,base_count_metric_ratio_to_1_month_ago,base_count_metric_ytd_sum,base_count_metric_max_for_month,base_count_metric_avg_3mth,base_count_metric_rolling_sum_3_month
 2021-01-01,2021-01-01,TRUE,FALSE,0,0,,0,0,0.000,0
 2021-02-01,2021-01-01,TRUE,FALSE,1,1,,1,1,0.500,1
 2021-03-01,2021-01-01,TRUE,FALSE,0,-1,0,1,0,0.333,1

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -11,13 +11,14 @@ VARIABLE SETTING ROUND 1: List Vs Single Metric!
 ############ #}
 
 {% if metric_list is not iterable %}
-    {% set single_metric = metric_list %}
-
-{% elif metric_list | length == 1 %}
-    {% set single_metric = metric_list[0] %}
-
+    {% set metric_list = [metric_list] %}
 {% endif %}
 
+{% if metric_list | length > 1 %}
+    {% set is_multiple_metrics = true %}
+{% else %}
+    {% set is_multiple_metrics = false %}
+{% endif %}
 
 {# ############
 VALIDATION ROUND ONE - THE MACRO LEVEL!
@@ -36,20 +37,19 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
 {%- endif %}
 
 {# #### TODO: CREATE MACRO FOR ERROR MESSAGE
-        - reshape so we can loop in all circumstances 
-  #}
+        - reshape so we can loop in all circumstances #}
 
-{% if metric_list is iterable and (metric_list is not string and metric_list is not mapping) %}
-    {% for metric in metric_list %}
-        {% if metric.type != "expression" and metric.metrics | length > 0 %}
-            {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
-        {%- endif %}
-    {% endfor %}
-{% else %}
+{# {% if metric_list is iterable and (metric_list is not string and metric_list is not mapping) %} #}
+{% for metric in metric_list %}
+    {% if metric.type != "expression" and metric.metrics | length > 0 %}
+        {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
+    {%- endif %}
+{% endfor %}
+{# {% else %}
     {% if single_metric.type != "expression" and single_metric.metrics | length > 0 %}
         {%- do exceptions.raise_compiler_error("The metric " ~ single_metric.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
-    {%- endif %}
-{%- endif %}
+    {%- endif %} #}
+{# {%- endif %} #}
 
 {# ############
 LETS SET SOME VARIABLES!
@@ -57,56 +57,7 @@ LETS SET SOME VARIABLES!
 
 {# We are creating the metric tree here - this includes all the leafs (first level parents)
 , the expression metrics, and the full combination of them both #}
-{%- set metric_tree = {'full_set':[],'leaf_set':[],'expression_set':[],'base_set':[],'ordered_expression_set':{}} -%}
-
-{% if metric_list is iterable and (metric_list is not string and metric_list is not mapping) %} 
-    {% set base_set_list = []%}
-    {% for metric in metric_list %}
-        {%- do base_set_list.append(metric.name) -%}
-        {%- set metric_tree = metrics.get_metric_tree(metric ,metric_tree) -%}
-    {%endfor%}
-    {%- do metric_tree.update({'base_set':base_set_list}) -%}
-
-{% else %}
-    {%- do metric_tree.update({'base_set':single_metric.name}) -%}
-    {%- set metric_tree = metrics.get_metric_tree(single_metric ,metric_tree) -%}
-{% endif %}
-
-{# Now we will iterate over the metric tree and make it a unique list to account for duplicates #}
-{% set full_set = [] %}
-{% set leaf_set = [] %}
-{% set expression_set = [] %}
-{% set base_set = [] %}
-
-{% for metric in metric_tree['full_set']|unique%}
-    {% do full_set.append(metric)%}
-{% endfor %}
-{%- do metric_tree.update({'full_set':full_set}) -%}
-
-{% for metric in metric_tree['leaf_set']|unique%}
-    {% do leaf_set.append(metric)%}
-{% endfor %}
-{%- do metric_tree.update({'leaf_set':leaf_set}) -%}
-
-
-{% for metric in metric_tree['expression_set']|unique%}
-    {% do expression_set.append(metric)%}
-{% endfor %}
-{%- do metric_tree.update({'expression_set':expression_set}) -%}
-
-{% for metric in metric_tree['leaf_set']|unique%}
-    {%- do metric_tree['ordered_expression_set'].pop(metric) -%}
-{% endfor %}
-
-{# This section overrides the expression set by ordering the metrics on their depth so they 
-can be correctly referenced in the downstream sql query #}
-{% set ordered_expression_list = []%}
-{% for item in metric_tree['ordered_expression_set']|dictsort(false, 'value') %}
-    {% if item[0] in metric_tree["expression_set"]%}
-        {% do ordered_expression_list.append(item[0])%}
-    {% endif %}
-{% endfor %}
-{%- do metric_tree.update({'expression_set':ordered_expression_list}) -%}
+{%- set metric_tree = metrics.get_metric_tree(metric_list) %}
 
 {# Here we set the calendar table as a variable, which ensures the default overwritten if they include
 a custom calendar #}
@@ -114,19 +65,25 @@ a custom calendar #}
 
 {# Here we are creating the dimension list which has the list of all dimensions that 
 are a part of the metric. This has additional logic for multiple metrics #}
-{% if metric_list is iterable and (metric_list is not string and metric_list is not mapping) %} 
-    {%- set dimension_list = [] -%}
-    {% for metric in metric_list %}
-        {%- set metric_dimensions= metrics.get_valid_dimension_list(metric) -%}
-        {%- set new_dimensions = ( metric_dimensions | reject('in',dimension_list) | list) -%}
-        {% for dim in new_dimensions %}
-            {%- do dimension_list.append(dim) -%}
-        {% endfor %}
-    {%endfor%}
+{# {% if is_multiple_metrics %}  #}
+    {# TODO #48 get valid common dimension name to clarify what is #}
+{%- set dimension_list = [] -%}
+{% for metric in metric_list %}
+    {# get all dimensions in metric  #}
+    {%- set metric_dimensions= metrics.get_valid_dimension_list(metric) -%}
+    {# This line removes any of the dimensions for loop metric that don't exist in the dimension list already
+    This creates a smaller list that only contains the subset #}
 
-{% else %}
-    {%- set dimension_list = metrics.get_valid_dimension_list(single_metric) -%}
-{% endif %}
+    {# TODO #50 build common list across all metrics and then find ones that appear X (metric count) times  #}
+    {%- set new_dimensions = ( metric_dimensions | reject('in',dimension_list) | list) -%}
+    {% for dim in new_dimensions %}
+        {%- do dimension_list.append(dim) -%}
+    {% endfor %}
+{%endfor%}
+
+{# {% else %}
+    {%- set dimension_list = metrics.get_valid_dimension_list(metric_list) -%} #}
+{# {% endif %} #}
 
 {# We have to break out calendar dimensions as their own list of acceptable dimensions. 
 This is because of the date-spining. If we don't do this, it creates impossible combinations
@@ -136,7 +93,7 @@ of calendar dimension + base dimensions #}
 {# Additionally, we also have to restrict the dimensions coming in from the macro to 
 no longer include those we've designated as calendar dimensions. That way they 
 are correctly handled by the spining. We override the dimensions variable for 
-cleanliness#}
+cleanliness #}
 {%- set dimensions = metrics.get_non_calendar_dimension_list(dimensions) -%}
 {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
 
@@ -144,20 +101,20 @@ cleanliness#}
 VALIDATION ROUND TWO - CONFIG ELEMENTS!
 ############ #}
 
-{#- /* TODO: Do I need to validate that the requested grain is defined on the metric? */ #}
+{#- /* TODO: #49 Do I need to validate that the requested grain is defined on the metric? */ #}
 {#- /* TODO: build a list of failures and return them all at once*/ #}
-{% if metric_list is iterable and (metric_list is not string and metric_list is not mapping) %} 
-    {% for metric in metric_list %}
-        {%- for calc_config in secondary_calculations if calc_config.aggregate %}
-            {%- do metrics.validate_aggregate_coherence(metric.type, calc_config.aggregate) %}
-        {%- endfor %}
-    {%endfor%}
+{# {% if is_multiple_metrics %}  #}
+{% for metric in metric_list %}
+    {%- for calc_config in secondary_calculations if calc_config.aggregate %}
+        {%- do metrics.validate_aggregate_coherence(metric.type, calc_config.aggregate) %}
+    {%- endfor %}
+{%endfor%}
 
-{% else %}
+{# {% else %}
     {%- for calc_config in secondary_calculations if calc_config.aggregate %}
         {%- do metrics.validate_aggregate_coherence(single_metric.type, calc_config.aggregate) %}
-    {%- endfor %}
-{% endif %}
+    {%- endfor %} #}
+{# {% endif %} #}
 
 
 {#- /* TODO: build a list of failures and return them all at once*/ #}
@@ -168,6 +125,8 @@ VALIDATION ROUND TWO - CONFIG ELEMENTS!
 {# This section will validate that the metric dimensions are contained within the appropriate 
 list of metrics #}
 
+{# rename dimensions to denote that this is a filtered list of the base input from the macro #}
+
 {%- for dim in dimensions -%}
     {% do metrics.is_valid_dimension(dim, dimension_list)  %}
 {%- endfor %}
@@ -175,6 +134,8 @@ list of metrics #}
 {# ############
 LET THE COMPOSITION BEGIN!
 ############ #}
+
+{{ log("Metric Tree: " ~ metric_tree, info=true) }}
 
 {# First we add the calendar table - we only need to do this once no matter how many
 metrics there are #}
@@ -189,14 +150,14 @@ metrics there are #}
     {# If composite, we begin by looping through each of the metric names that make
     up the composite metric. #}
 
-    {% for metric_name in metric_tree["leaf_set"]%}
+    {% for metric_name in metric_tree["parent_set"]%}
         {%- set loop_metric = metrics.get_metric_relation(metric_name) -%}
         {%- set loop_base_model = loop_metric.model.split('\'')[1]  -%}
         {%- set loop_model = metrics.get_model_relation(loop_base_model if execute else "") %}
         {{ metrics.build_metric_sql(loop_metric,loop_model,grain,dimensions,secondary_calculations,start_date,end_date,where,calendar_tbl,relevant_periods,calendar_dimensions) }}
     {% endfor %}
 
-    {{ metrics.gen_joined_metrics_cte(metric_tree["leaf_set"],metric_tree["expression_set"],metric_tree["ordered_expression_set"], grain, dimensions,calendar_dimensions,secondary_calculations,relevant_periods) }}
+    {{ metrics.gen_joined_metrics_cte(metric_tree["parent_set"],metric_tree["expression_set"],metric_tree["ordered_expression_set"], grain, dimensions,calendar_dimensions,secondary_calculations,relevant_periods) }}
     {{ metrics.gen_secondary_calculation_cte(metric_tree["base_set"],dimensions,grain,metric_tree["full_set"],secondary_calculations,calendar_dimensions) }}
     {{ metrics.gen_final_cte(metric_tree["base_set"],grain,metric_tree["full_set"],secondary_calculations) }}
     
@@ -205,10 +166,16 @@ metrics there are #}
 
     {# We only set these variables here because they're only needed if it isn't a 
     composite metric #}
-    {%- set base_model = single_metric.model.split('\'')[1]  -%}
-    {%- set model = metrics.get_model_relation(base_model if execute else "") %}
+    {# {%- set base_model = metric_list.model.split('\'')[1]  -%}
+    {%- set model = metrics.get_model_relation(base_model if execute else "") %} #}
 
-    {{ metrics.build_metric_sql(single_metric,model,grain,dimensions,secondary_calculations,start_date,end_date,where,calendar_tbl,relevant_periods,calendar_dimensions) }}
+    {% for metric_name in metric_tree["full_set"]%}
+        {%- set single_metric = metric(metric_name) -%}
+        {%- set single_base_model = single_metric.model.split('\'')[1]  -%}
+        {%- set single_model = metrics.get_model_relation(single_base_model if execute else "") %}
+        {{ metrics.build_metric_sql(single_metric,single_model,grain,dimensions,secondary_calculations,start_date,end_date,where,calendar_tbl,relevant_periods,calendar_dimensions) }}
+    {% endfor %}
+    {# {{ metrics.build_metric_sql(metric_list,model,grain,dimensions,secondary_calculations,start_date,end_date,where,calendar_tbl,relevant_periods,calendar_dimensions) }} #}
     {{ metrics.gen_secondary_calculation_cte(metric_tree["base_set"],dimensions,grain,metric_tree["full_set"],secondary_calculations,calendar_dimensions) }}
     {{ metrics.gen_final_cte(metric_tree["base_set"],grain,metric_tree["full_set"],secondary_calculations) }}
     

--- a/macros/sql_gen/gen_final_cte.sql
+++ b/macros/sql_gen/gen_final_cte.sql
@@ -42,7 +42,7 @@
 
         -- single metric without secondary calculations
 
-        select * from {{base_set}}__final 
+        select * from {{base_set[0]}}__final 
 
     {% endif %}
 

--- a/macros/sql_gen/gen_joined_metrics_cte.sql
+++ b/macros/sql_gen/gen_joined_metrics_cte.sql
@@ -7,6 +7,7 @@
 {# This section is a hacky workaround to account for postgres changes #}
 {% set cte_numbers = []%}
 {% set unique_cte_numbers = []%}
+{# the cte numbers are more representative of node depth #}
 {% if expression_set | length > 0 %}
     {% for metric in ordered_expression_set%}
         {% do cte_numbers.append(ordered_expression_set[metric]) %}
@@ -14,7 +15,6 @@
     {% for cte_num in cte_numbers|unique%}
         {% do unique_cte_numbers.append(cte_num) %}
     {% endfor %}
-    {% set last_cte_number = unique_cte_numbers[0] %}
 {% endif %}
 
 
@@ -116,7 +116,8 @@
             {% endfor %}
         from first_join_metrics
         {% if expression_set | length > 0 %}
-            left join "{{last_cte_number}}__join_metrics"
+        {# TODO check sort logic #}
+            left join "999__join_metrics"
                 using ( date_{{grain}},
                     {% for calendar_dim in calendar_dimensions %}
                         {{ calendar_dim }},

--- a/macros/sql_gen/gen_secondary_calculations_cte.sql
+++ b/macros/sql_gen/gen_secondary_calculations_cte.sql
@@ -40,7 +40,7 @@ easier for not having to update the working secondary calc logic #}
         {% if full_set|length > 1 %} 
             joined_metrics
         {% else %} 
-            {{base_set}}__final
+            {{base_set[0]}}__final
         {% endif %}
 )
 

--- a/macros/variables/update_metric_tree.sql
+++ b/macros/variables/update_metric_tree.sql
@@ -1,0 +1,69 @@
+{% macro update_metric_tree(metric,metric_tree,metric_count=999)%}
+    
+    {# Now we see if the node already exists in the metric tree and return that if 
+    it does so that we're not creating duplicates #}
+    {%- if metric.name not in metric_tree|map(attribute="full_set") -%}
+
+        {%- set full_set = metric_tree["full_set"] -%}
+        {%- do full_set.append(metric.name) -%}
+        {%- do metric_tree.update({'full_set':full_set}) -%}
+
+    {%- endif -%}
+
+    {%- do metric_tree["ordered_expression_set"].update({metric.name:metric_count}) -%}
+    {%- set metric_count = metric_count - 1 -%}
+
+    {# Here we create two sets, sets being the same as lists but they account for uniqueness. 
+    One is the full set, which contains all of the parent metrics and the other is the leaf
+    set, which we'll use to determine the leaf, or base metrics. #}
+
+    {# We define parent nodes as being the parent nodes that begin with metric, which lets
+    us filter out model nodes #}
+    {%- set parent_metrics = metrics.get_metric_unique_id_list(metric) -%}
+
+    {# We set an if condition based on if parent nodes. If there are none, then this metric
+    is a leaf node and any recursive loop should end #}
+        {%- if parent_metrics | length > 0 -%}
+
+            {# Now we finally recurse through the nodes. We begin by filtering the overall list we
+            recurse through by limiting it to depending on metric nodes and not ALL nodes #}
+            {%- for parent_id in parent_metrics -%}
+
+                {# Then we add the parent_id of the metric to the full set. If it already existed
+                then it won't make an impact but we want to make sure it is represented #}
+                {# {%- do full_set.append(parent_id) -%} #}
+                {%- set full_set_plus = metric_tree["full_set"] -%}
+                {%- if parent_id in metric_tree|map(attribute="full_set") -%}
+                    {%- do full_set_plus.append(parent_id) -%}
+                {%- endif -%}
+                {%- do metric_tree.update({'full_set':full_set_plus}) -%}
+                {# The parent_id variable here is a mapping back to the provided manifest and doesn't 
+                allow for string parsing. So we create this variable to use instead #}
+                {# {%- set parent_metric_name = (parent_id | string).split('.')[2] -%} #}
+
+                {# And here we re-run the current macro but fill in the parent_id so that we loop again
+                with that metric information. You may be wondering, why are you using parent_id? Doesn't 
+                the DAG always go from parent to child? Normally, yes! With this, no! We're reversing the 
+                DAG and going up to parents to find the leaf nodes that are really parent nodes. #}
+                {%- set new_parent = metrics.get_metric_relation(parent_id) -%}
+
+                {%- set metric_tree =  metrics.update_metric_tree(new_parent,metric_tree,metric_count) -%}
+
+            {%- endfor -%}
+        
+        {%- else -%}
+
+            {%- set parent_set_plus = metric_tree["parent_set"] -%}
+            {%- if parent_id in metric_tree|map(attribute="full_set") -%}
+                {%- do parent_set_plus.append(metric.name) -%}
+            {%- endif -%}
+            {%- do metric_tree.update({'parent_set':parent_set_plus}) -%}
+
+        {%- endif -%}
+
+        {%- set expression_set_plus = ( metric_tree["full_set"] | reject('in',metric_tree["parent_set"]) | list) -%}
+        {%- do metric_tree.update({'expression_set':expression_set_plus}) -%}
+
+    {%- do return(metric_tree) -%}
+
+{% endmacro %}


### PR DESCRIPTION
## Description
This PR introduces a number of changes based upon #47 . Namely:
- Renaming `get_metric_tree` to `update_metric_tree` to reflect the logic that is just updating the tree
- Creating a new `get_metric_tree` that creates and returns the metric tree along with additional logic

It also addresses #43 by taking single metrics provided and adding them into a list. This allows us to reduce the complexity of downstream if functions to instead just always iterate on a list.