### PR TITLE
Grain Validation

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -31,6 +31,12 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
 {%- endif %}
 
 {% for metric in metric_list %}
+    {% if grain not in metric.time_grains%}
+        {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " does not have the provided time grain " ~ grain ~ "defined in the metric definition.") %}
+    {% endif %}
+{% endfor %}
+
+{% for metric in metric_list %}
     {% if metric.type != "expression" and metric.metrics | length > 0 %}
         {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
     {%- endif %}

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -34,7 +34,7 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
     {%- do exceptions.raise_compiler_error("No date grain provided") %}
 {%- endif %}
 
-{% do metrics.validate_grain(grain, metric_tree['full_set'])%}
+{% do metrics.validate_grain(grain, metric_tree['full_set'], metric_tree['base_set'])%}
 
 {% do metrics.validate_expression_metrics(metric_tree['full_set'])%}
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -34,7 +34,7 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
     {%- do exceptions.raise_compiler_error("No date grain provided") %}
 {%- endif %}
 
-{% do metrics.validate_grain(grain,metric_tree['full_set'])%}
+{% do metrics.validate_grain(grain, metric_tree['full_set'])%}
 
 {% do metrics.validate_expression_metrics(metric_tree['full_set'])%}
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -14,6 +14,10 @@ VARIABLE SETTING ROUND 1: List Vs Single Metric!
     {% set metric_list = [metric_list] %}
 {% endif %}
 
+{# We are creating the metric tree here - this includes all the leafs (first level parents)
+, the expression metrics, and the full combination of them both #}
+{%- set metric_tree = metrics.get_metric_tree(metric_list) %}
+
 {# ############
 VALIDATION ROUND ONE - THE MACRO LEVEL!
 ############ #}
@@ -30,25 +34,13 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
     {%- do exceptions.raise_compiler_error("No date grain provided") %}
 {%- endif %}
 
-{% for metric in metric_list %}
-    {% if grain not in metric.time_grains%}
-        {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " does not have the provided time grain " ~ grain ~ "defined in the metric definition.") %}
-    {% endif %}
-{% endfor %}
+{% do metrics.validate_grain(grain,metric_tree['full_set'])%}
 
-{% for metric in metric_list %}
-    {% if metric.type != "expression" and metric.metrics | length > 0 %}
-        {%- do exceptions.raise_compiler_error("The metric " ~ metric.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
-    {%- endif %}
-{% endfor %}
+{% do metrics.validate_expression_metrics(metric_tree['full_set'])%}
 
 {# ############
 LETS SET SOME VARIABLES!
 ############ #}
-
-{# We are creating the metric tree here - this includes all the leafs (first level parents)
-, the expression metrics, and the full combination of them both #}
-{%- set metric_tree = metrics.get_metric_tree(metric_list) %}
 
 {# Here we set the calendar table as a variable, which ensures the default overwritten if they include
 a custom calendar #}

--- a/macros/validation/validate_expression_metrics.sql
+++ b/macros/validation/validate_expression_metrics.sql
@@ -1,7 +1,7 @@
 {% macro validate_expression_metrics(full_set) %}
 
     {# We loop through the full set here to ensure that metrics that aren't listed 
-    as expression are note dependent on another metric.  #}
+    as expression are not dependent on another metric.  #}
 
     {% for metric_name in full_set %}
         {% set metric_relation = metric(metric_name)%}

--- a/macros/validation/validate_expression_metrics.sql
+++ b/macros/validation/validate_expression_metrics.sql
@@ -1,12 +1,13 @@
-{% macro validate_expression_metrics(full_set) %}
+{% macro validate_expression_metrics(metric_names) %}
 
     {# We loop through the full set here to ensure that metrics that aren't listed 
     as expression are not dependent on another metric.  #}
 
-    {% for metric_name in full_set %}
+    {% for metric_name in metric_names %}
         {% set metric_relation = metric(metric_name)%}
+        {% set metric_relation_depends_on = metric_relation.metrics  | join (",") %}
         {% if metric_relation.type != "expression" and metric_relation.metrics | length > 0 %}
-            {%- do exceptions.raise_compiler_error("The metric " ~ metric_relation.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
+            {%- do exceptions.raise_compiler_error("The metric " ~ metric_relation.name ~" also references '" ~ metric_relation_depends_on ~ "' but its type is '" ~ metric_relation.type ~ "'. Only metrics of type expression can reference other metrics.") %}
         {%- endif %}
     {% endfor %}
 

--- a/macros/validation/validate_expression_metrics.sql
+++ b/macros/validation/validate_expression_metrics.sql
@@ -1,0 +1,13 @@
+{% macro validate_expression_metrics(full_set) %}
+
+    {# We loop through the full set here to ensure that metrics that aren't listed 
+    as expression are note dependent on another metric.  #}
+
+    {% for metric_name in full_set %}
+        {% set metric_relation = metric(metric_name)%}
+        {% if metric_relation.type != "expression" and metric_relation.metrics | length > 0 %}
+            {%- do exceptions.raise_compiler_error("The metric " ~ metric_relation.name ~ " was not an expression and dependent on another metric. This is not currently supported - if this metric depends on another metric, please change the type to expression.") %}
+        {%- endif %}
+    {% endfor %}
+
+{% endmacro %}

--- a/macros/validation/validate_grain.sql
+++ b/macros/validation/validate_grain.sql
@@ -1,0 +1,13 @@
+{% macro validate_grain(grain, full_set) %}
+
+    {# We loop through the full set here to ensure that the provided grain works for all metrics
+    returned or used, not just those listed #}
+
+    {% for metric_name in full_set %}
+        {% set metric_relation = metric(metric_name)%}
+        {% if grain not in metric_relation.time_grains%}
+            {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " does not have the provided time grain " ~ grain ~ "defined in the metric definition.") %}
+        {% endif %}
+    {% endfor %}
+
+{% endmacro %}

--- a/macros/validation/validate_grain.sql
+++ b/macros/validation/validate_grain.sql
@@ -1,12 +1,16 @@
-{% macro validate_grain(grain, full_set) %}
+{% macro validate_grain(grain, all_metric_names, base_metric_names) %}
 
     {# We loop through the full set here to ensure that the provided grain works for all metrics
     returned or used, not just those listed #}
 
-    {% for metric_name in full_set %}
+    {% for metric_name in all_metric_names %}
         {% set metric_relation = metric(metric_name)%}
         {% if grain not in metric_relation.time_grains%}
-            {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " does not have the provided time grain " ~ grain ~ "defined in the metric definition.") %}
+            {% if metric_name not in base_metric_names %}
+                {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " is an upstream metric of one of the provided metrics. The grain " ~ grain ~ " is not defined in its metric definition.") %}
+            {% else %}
+                {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " does not have the provided time grain " ~ grain ~ " defined in the metric definition.") %}
+            {% endif %}
         {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
## Description
This PR intends to address #49 . We had initially scoped it as creating a dictionary that confirms the provided grain is listed in both metrics but that was a more complicated solution than what is actually required. The real solution hit me on the head after working out the prior.

We just loop through each metric and check that the metric is in the accepted list of time grains. If its not, we raise the error for the first metric it doesn't pass. 

```sql
{# We loop through the full set here to ensure that the provided grain works for all metrics
returned or used, not just those listed #}
{% for metric_name in metric_tree['full_set'] %}
    {% set metric_relation = metric(metric_name)%}
    {% if grain not in metric_relation.time_grains%}
        {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " does not have the provided time grain " ~ grain ~ "defined in the metric definition.") %}
    {% endif %}
{% endfor %}
```

Simpler and easier to debug. Win win!

### Addition In New Macro Form
Changed to reflect that we need to loop through all metrics in full set, not just those listed in the macro call. Otherwise there is the possibility of DAG issues where a metric 2+ upstream doesn't have `day` listed as an acceptable grain. Figured if I'm gonna do this we might as well do the same for the compilation logic around expression metrics as well. 

### What This PR Adds:
- Adds the macro `validate_grain` which checks that the grain provided is present in all metrics returned (both listed and upstream)
- Adds the macro `validate_expression_metrics` which checks that all metrics returned are correctly listed as expressions if they depend on a metric. 
