### PR TITLE
Hotfixing Where Clause

### DIFF
--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -1,9 +1,9 @@
-{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
+{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
     {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
 {% endmacro %}
 
 
-{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where = []) -%}
+{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -110,12 +110,12 @@ metrics there are #}
         {%- set loop_metric = metrics.get_metric_relation(metric_name) -%}
         {%- set loop_base_model = loop_metric.model.split('\'')[1]  -%}
         {%- set loop_model = metrics.get_model_relation(loop_base_model if execute else "") %}
-        {{ metrics.build_metric_sql(loop_metric, loop_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date,where,calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
+        {{ metrics.build_metric_sql(loop_metric, loop_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date,calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
     {% endfor %}
 
     {{ metrics.gen_joined_metrics_cte(metric_tree["parent_set"], metric_tree["expression_set"], metric_tree["ordered_expression_set"], grain, non_calendar_dimensions, calendar_dimensions, secondary_calculations, relevant_periods) }}
     {{ metrics.gen_secondary_calculation_cte(metric_tree["base_set"], non_calendar_dimensions, grain, metric_tree["full_set"], secondary_calculations, calendar_dimensions) }}
-    {{ metrics.gen_final_cte(metric_tree["base_set"], grain, metric_tree["full_set"], secondary_calculations) }}
+    {{ metrics.gen_final_cte(metric_tree["base_set"], grain, metric_tree["full_set"], secondary_calculations,where) }}
     
     {# If it is NOT a composite metric, we run the baseline model #}
 {%- else -%}
@@ -127,10 +127,10 @@ metrics there are #}
         {%- set single_metric = metric(metric_name) -%}
         {%- set single_base_model = single_metric.model.split('\'')[1]  -%}
         {%- set single_model = metrics.get_model_relation(single_base_model if execute else "") %}
-        {{ metrics.build_metric_sql(single_metric, single_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date, where, calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
+        {{ metrics.build_metric_sql(single_metric, single_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date, calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
     {% endfor %}
     {{ metrics.gen_secondary_calculation_cte(metric_tree["base_set"], non_calendar_dimensions, grain, metric_tree["full_set"], secondary_calculations, calendar_dimensions) }}
-    {{ metrics.gen_final_cte(metric_tree["base_set"], grain, metric_tree["full_set"], secondary_calculations) }}
+    {{ metrics.gen_final_cte(metric_tree["base_set"], grain, metric_tree["full_set"], secondary_calculations,where) }}
     
 {%- endif -%}
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -34,6 +34,10 @@ VALIDATION ROUND ONE - THE MACRO LEVEL!
     {%- do exceptions.raise_compiler_error("No date grain provided") %}
 {%- endif %}
 
+{% if where is iterable and (where is not string and where is not mapping) %}
+    {%- do exceptions.raise_compiler_error("From v0.3.0 onwards, the where clause takes a single string, not a list of filters. Please fix to reflect this change") %}
+{% endif %}
+
 {% do metrics.validate_grain(grain, metric_tree['full_set'], metric_tree['base_set'])%}
 
 {% do metrics.validate_expression_metrics(metric_tree['full_set'])%}

--- a/macros/sql_gen/build_metric_sql.sql
+++ b/macros/sql_gen/build_metric_sql.sql
@@ -1,8 +1,8 @@
-{%- macro build_metric_sql(metric, model, grain, dimensions, secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions,dimensions_provided) %}
+{%- macro build_metric_sql(metric, model, grain, dimensions, secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions,dimensions_provided) %}
     
     {# This is the SQL Gen part - we've broken each component out into individual macros #}
     {# We broke this out so it can loop for composite metrics #}
-    {{metrics.gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions)}}
+    {{metrics.gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions)}}
     
     {# Adding conditional logic to exclude the unique combinations of dimensions if there are no dimensions #}
     {% if dimensions_provided == true %}

--- a/macros/sql_gen/gen_aggregate_cte.sql
+++ b/macros/sql_gen/gen_aggregate_cte.sql
@@ -1,8 +1,8 @@
-{% macro gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions) %}
-    {{ return(adapter.dispatch('gen_aggregate_cte', 'metrics')(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions)) }}
+{% macro gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions) %}
+    {{ return(adapter.dispatch('gen_aggregate_cte', 'metrics')(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions)) }}
 {% endmacro %}
 
-{% macro default__gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions) %}
+{% macro default__gen_aggregate_cte(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions) %}
 
     ,{{metric.name}}__aggregate as (
         {# This is the most important CTE. Instead of joining all relevant information
@@ -35,7 +35,7 @@
             gen_primary_metric_aggregate macro. Take a look at that one if you're curious #}
             {{- metrics.gen_primary_metric_aggregate(metric.type, 'property_to_aggregate') }} as {{ metric.name }},
             {{ dbt_utils.bool_or('metric_date_day is not null') }} as has_data
-        from ({{metrics.gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions)}}) as base_query
+        from ({{metrics.gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions)}}) as base_query
         group by {{ metrics.gen_group_by(grain,dimensions,calendar_dimensions,relevant_periods) }}
     )
 

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -1,8 +1,8 @@
-{% macro gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions) %}
-    {{ return(adapter.dispatch('gen_base_query', 'metrics')(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions)) }}
+{% macro gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions) %}
+    {{ return(adapter.dispatch('gen_base_query', 'metrics')(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions)) }}
 {% endmacro %}
 
-{% macro default__gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions) %}
+{% macro default__gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions) %}
 
     {# This is the "base" CTE which selects the fields we need to correctly 
     calculate the metric.  #}
@@ -49,7 +49,7 @@
         )      
     {% endif %} 
 
-    -- metric where clauses...
+    -- metric filter clauses...
     {% if metric.filters %}
     and (
         {%- for filter in metric.filters %}
@@ -59,20 +59,9 @@
     )
     {% endif%}
 
-
-    -- metric where clauses...
-    {% if where %}
-    and (
-        {%- for filter in where %}
-            {{ filter }}
-            {% if not loop.last %} and {% endif %}
-        {%- endfor %}
-    )
-    {% endif %}
-
 {% endmacro %}
 
-{% macro bigquery__gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, where, calendar_tbl,relevant_periods,calendar_dimensions) %}
+{% macro bigquery__gen_base_query(metric,model,grain,dimensions,secondary_calculations, start_date, end_date, calendar_tbl,relevant_periods,calendar_dimensions) %}
 
     {# This is the "base" CTE which selects the fields we need to correctly 
     calculate the metric.  #}
@@ -119,7 +108,7 @@
         )      
     {% endif %} 
 
-    -- metric where clauses...
+    -- metric filter clauses...
     {% if metric.filters %}
     and (
         {%- for filter in metric.filters %}
@@ -128,16 +117,5 @@
         {%- endfor %}
     )
     {% endif%}
-
-
-    -- metric where clauses...
-    {% if where %}
-    and (
-        {%- for filter in where %}
-            {{ filter }}
-            {% if not loop.last %} and {% endif %}
-        {%- endfor %}
-    )
-    {% endif %}
 
 {% endmacro %}

--- a/macros/sql_gen/gen_final_cte.sql
+++ b/macros/sql_gen/gen_final_cte.sql
@@ -19,12 +19,7 @@
 
             -- metric where clauses...
         {% if where %}
-        where (
-            {%- for filter in where %}
-                {{ filter }}
-                {% if not loop.last %} and {% endif %}
-            {%- endfor %}
-        )
+        where {{ where }}
         {% endif %}
 
     {% else %}
@@ -33,12 +28,7 @@
 
     -- metric where clauses...
     {% if where %}
-    where (
-        {%- for filter in where %}
-            {{ filter }}
-            {% if not loop.last %} and {% endif %}
-        {%- endfor %}
-    )
+        where {{ where }}
     {% endif %}
 
     {% endif %}
@@ -60,12 +50,7 @@
 
         -- metric where clauses...
         {% if where %}
-        where (
-            {%- for filter in where %}
-                {{ filter }}
-                {% if not loop.last %} and {% endif %}
-            {%- endfor %}
-        )
+        where {{ where }}
         {% endif %}
 
         {% else %}
@@ -77,12 +62,7 @@
 
         -- metric where clauses...
         {% if where %}
-        where (
-            {%- for filter in where %}
-                {{ filter }}
-                {% if not loop.last %} and {% endif %}
-            {%- endfor %}
-        )
+        where {{ where }}
         {% endif %}
 
     {% endif %}

--- a/macros/sql_gen/gen_final_cte.sql
+++ b/macros/sql_gen/gen_final_cte.sql
@@ -1,8 +1,8 @@
-{% macro gen_final_cte(base_set,grain,full_set,secondary_calculations) %}
-    {{ return(adapter.dispatch('gen_final_cte', 'metrics')(base_set,grain,full_set,secondary_calculations)) }}
+{% macro gen_final_cte(base_set,grain,full_set,secondary_calculations, where) %}
+    {{ return(adapter.dispatch('gen_final_cte', 'metrics')(base_set,grain,full_set,secondary_calculations, where)) }}
 {% endmacro %}
 
-{% macro default__gen_final_cte(base_set,grain,full_set,secondary_calculations) %}
+{% macro default__gen_final_cte(base_set,grain,full_set,secondary_calculations, where) %}
 
 {%- if full_set | length > 1 %}
 
@@ -17,9 +17,29 @@
 
         select * from final 
 
+            -- metric where clauses...
+        {% if where %}
+        where (
+            {%- for filter in where %}
+                {{ filter }}
+                {% if not loop.last %} and {% endif %}
+            {%- endfor %}
+        )
+        {% endif %}
+
     {% else %}
 
     select * from joined_metrics
+
+    -- metric where clauses...
+    {% if where %}
+    where (
+        {%- for filter in where %}
+            {{ filter }}
+            {% if not loop.last %} and {% endif %}
+        {%- endfor %}
+    )
+    {% endif %}
 
     {% endif %}
 
@@ -38,11 +58,32 @@
 
         select * from final 
 
+        -- metric where clauses...
+        {% if where %}
+        where (
+            {%- for filter in where %}
+                {{ filter }}
+                {% if not loop.last %} and {% endif %}
+            {%- endfor %}
+        )
+        {% endif %}
+
         {% else %}
 
         -- single metric without secondary calculations
 
         select * from {{base_set[0]}}__final 
+
+
+        -- metric where clauses...
+        {% if where %}
+        where (
+            {%- for filter in where %}
+                {{ filter }}
+                {% if not loop.last %} and {% endif %}
+            {%- endfor %}
+        )
+        {% endif %}
 
     {% endif %}
 

--- a/tests/functional/invalid_configs/test_invalid_where.py
+++ b/tests/functional/invalid_configs/test_invalid_where.py
@@ -46,6 +46,8 @@ metrics:
 class TestInvalidWhereMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/invalid_configs/test_invalid_where.py
+++ b/tests/functional/invalid_configs/test_invalid_where.py
@@ -17,7 +17,7 @@ from
 {{ metrics.calculate(metric('invalid_where'), 
     grain='month',
     dimensions=['had_discount'],
-    where=["order_country='Japan'"]
+    where="order_country='Japan'"
     )
 }}
 """
@@ -96,7 +96,7 @@ class TestInvalidWhereMetric:
         results = run_dbt(["seed"])
         assert len(results) == 1
 
-        # Here we expect the run to fail because the incorrect
-        # time grain won't allow it to compile
+        # Here we expect the run to fail because the value provided
+        # in the where clause isn't included in the final dataset
         results = run_dbt(["run"], expect_pass = False)
 

--- a/tests/functional/invalid_configs/test_invalid_where.py
+++ b/tests/functional/invalid_configs/test_invalid_where.py
@@ -1,0 +1,102 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/invalid_where.sql
+invalid_where_sql = """
+select *
+from 
+{{ metrics.calculate(metric('invalid_where'), 
+    grain='month',
+    dimensions=['had_discount'],
+    where=["order_country='Japan'"]
+    )
+}}
+"""
+
+# models/invalid_where.yml
+invalid_where_yml = """
+version: 2 
+models:
+  - name: invalid_where
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('invalid_where__expected')
+metrics:
+  - name: invalid_where
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+class TestInvalidWhereMetric:
+
+    # configuration in dbt_project.yml
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv
+            }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "invalid_where.sql": invalid_where_sql,
+            "invalid_where.yml": invalid_where_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        # Here we expect the run to fail because the incorrect
+        # time grain won't allow it to compile
+        results = run_dbt(["run"], expect_pass = False)
+

--- a/tests/functional/metric_options/date_grains/test_day_grain.py
+++ b/tests/functional/metric_options/date_grains/test_day_grain.py
@@ -90,6 +90,8 @@ date_day,day_grain_metric
 class TestDayGrain:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/date_grains/test_month_grain.py
+++ b/tests/functional/metric_options/date_grains/test_month_grain.py
@@ -51,6 +51,8 @@ date_month,month_grain_metric
 class TestmonthGrain:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/date_grains/test_week_grain.py
+++ b/tests/functional/metric_options/date_grains/test_week_grain.py
@@ -69,6 +69,8 @@ date_week,week_grain_metric
 class TestWeekGrain:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/dimensions/test_multi_dimension_base_metric.py
+++ b/tests/functional/metric_options/dimensions/test_multi_dimension_base_metric.py
@@ -58,6 +58,8 @@ date_month,had_discount,order_country,multi_dimension_base_sum_metric
 class TestMultiDimensionBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/dimensions/test_multi_dimension_expression_metric.py
+++ b/tests/functional/metric_options/dimensions/test_multi_dimension_expression_metric.py
@@ -73,6 +73,8 @@ date_month,had_discount,order_country,base_sum_metric,multi_dimension_expression
 class TestMultiDimensionExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/dimensions/test_single_dimension_base_metric.py
+++ b/tests/functional/metric_options/dimensions/test_single_dimension_base_metric.py
@@ -54,6 +54,8 @@ date_month,had_discount,single_dimension_base_sum_metric
 class TestSingleDimensionBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/dimensions/test_single_dimension_expression_metric.py
+++ b/tests/functional/metric_options/dimensions/test_single_dimension_expression_metric.py
@@ -69,6 +69,8 @@ date_month,had_discount,base_sum_metric,single_dimension_expression_metric
 class TestSingleDimensionExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/end_date/test_early_end_date_base_metric.py
+++ b/tests/functional/metric_options/end_date/test_early_end_date_base_metric.py
@@ -51,6 +51,8 @@ date_month,early_end_date_base_sum_metric
 class TestEarlyEndDateBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/end_date/test_early_end_date_expression_metric.py
+++ b/tests/functional/metric_options/end_date/test_early_end_date_expression_metric.py
@@ -66,6 +66,8 @@ date_month,base_sum_metric,end_date_expression_metric
 class TestEndDateExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/end_date/test_end_date_base_metric.py
+++ b/tests/functional/metric_options/end_date/test_end_date_base_metric.py
@@ -51,6 +51,8 @@ date_month,end_date_base_sum_metric
 class TestEndDateBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/end_date/test_end_date_expression_metric.py
+++ b/tests/functional/metric_options/end_date/test_end_date_expression_metric.py
@@ -66,6 +66,8 @@ date_month,base_sum_metric,end_date_expression_metric
 class TestEndDateExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types.py
@@ -63,6 +63,8 @@ date_month,base_sum_metric,base_count_metric
 class TestMultipleMetrics:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types_dimensions.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types_dimensions.py
@@ -66,6 +66,8 @@ date_month,had_discount,base_sum_metric,base_count_metric
 class TestMultipleMetricsWithDimension:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_expression_types.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_expression_types.py
@@ -62,6 +62,8 @@ date_month,base_sum_metric,expression_metric
 class TestMultipleMetricsWithExpression:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_expression_types_dimensions.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_expression_types_dimensions.py
@@ -65,6 +65,8 @@ date_month,had_discount,base_sum_metric,expression_metric
 class TestMultipleMetricsWithExpressionAndDimension:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_difference.py
+++ b/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_difference.py
@@ -95,6 +95,8 @@ else:
 class TestPeriodOverPeriodDifference:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_ratio.py
+++ b/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_ratio.py
@@ -69,6 +69,8 @@ else:
 class TestPeriodOverPeriodRatio:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_average.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_average.py
@@ -98,6 +98,8 @@ else:
 class TestPeriodToDateAverage:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count.py
@@ -101,6 +101,8 @@ else:
 class TestPeriodToDateCount:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count_distinct.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count_distinct.py
@@ -101,6 +101,8 @@ else:
 class TestPeriodToDateCountDistinct:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_expression.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_expression.py
@@ -89,6 +89,8 @@ else:
 class TestPeriodToDateExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_max.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_max.py
@@ -101,6 +101,8 @@ else:
 class TestPeriodToDateMax:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_min.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_min.py
@@ -101,6 +101,8 @@ else:
 class TestPeriodToDateMin:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_same_period_and_grain.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_same_period_and_grain.py
@@ -10,60 +10,87 @@ from tests.functional.fixtures import (
     fact_orders_yml,
 )
 
-# models/late_start_date_expression_metric.sql
-late_start_date_expression_metric_sql = """
+# models/same_period_and_grain.sql
+same_period_and_grain_sql = """
 select *
 from 
-{{ metrics.calculate(metric('late_start_date_expression_metric'), 
-    grain='month',
-    start_date='2022-02-04'
+{{ metrics.calculate(metric('same_period_and_grain'), 
+    grain='day',
+    secondary_calculations=[
+        metrics.period_to_date(aggregate="sum", period="day",alias="day_sum")
+    ]
     )
 }}
 """
 
-# models/base_sum_metric.yml
-base_sum_metric_yml = """
-version: 2 
-metrics:
-  - name: base_sum_metric
-    model: ref('fact_orders')
-    label: Total Discount ($)
-    timestamp: order_date
-    time_grains: [day, week, month]
-    type: sum
-    sql: order_total
-    dimensions:
-      - had_discount
-      - order_country
-"""
-
-# models/late_start_date_expression_metric.yml
-late_start_date_expression_metric_yml = """
+# models/same_period_and_grain.yml
+same_period_and_grain_yml = """
 version: 2 
 models:
-  - name: late_start_date_expression_metric
+  - name: same_period_and_grain
     tests: 
       - dbt_utils.equality:
-          compare_model: ref('late_start_date_expression_metric__expected')
+          compare_model: ref('same_period_and_grain__expected')
 metrics:
-  - name: late_start_date_expression_metric
-    label: Expression ($)
+  - name: same_period_and_grain
+    model: ref('fact_orders')
+    label: Count
     timestamp: order_date
     time_grains: [day, week, month]
-    type: expression
-    sql: "{{metric('base_sum_metric')}} + 1"
+    type: count
+    sql: customer_id
     dimensions:
       - had_discount
       - order_country
 """
 
-# seeds/late_start_date_expression_metric__expected.csv
-late_start_date_expression_metric__expected_csv = """
-date_month,base_sum_metric,late_start_date_expression_metric
-2022-02-01,5,6
+# seeds/same_period_and_grain__expected.csv
+same_period_and_grain__expected_csv = """
+date_day,same_period_and_grain,same_period_and_grain_day_sum
+2022-02-03,1,1
+2022-01-12,0,0
+2022-01-07,0,0
+2022-02-01,0,0
+2022-01-08,1,1
+2022-02-10,0,0
+2022-01-28,1,1
+2022-01-14,0,0
+2022-02-15,1,1
+2022-02-08,0,0
+2022-01-21,1,1
+2022-02-13,1,1
+2022-02-04,0,0
+2022-01-17,0,0
+2022-02-09,0,0
+2022-01-13,1,1
+2022-02-06,0,0
+2022-01-11,0,0
+2022-02-12,0,0
+2022-01-16,0,0
+2022-02-05,0,0
+2022-01-15,0,0
+2022-01-23,0,0
+2022-01-06,1,1
+2022-01-26,0,0
+2022-01-22,1,1
+2022-01-19,0,0
+2022-01-25,0,0
+2022-01-09,0,0
+2022-02-14,0,0
+2022-01-10,0,0
+2022-01-30,0,0
+2022-02-11,0,0
+2022-01-27,0,0
+2022-01-29,0,0
+2022-01-24,0,0
+2022-01-31,0,0
+2022-01-20,1,1
+2022-01-18,0,0
+2022-02-02,0,0
+2022-02-07,0,0
 """.lstrip()
 
-class TestStartDateExpressionMetric:
+class TestSamePeriodAndGrainCount:
 
     # configuration in dbt_project.yml
     # setting bigquery as table to get around query complexity 
@@ -92,24 +119,22 @@ class TestStartDateExpressionMetric:
                 ]
         }
 
-
     # everything that goes in the "seeds" directory
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
             "fact_orders_source.csv": fact_orders_source_csv,
-            "late_start_date_expression_metric__expected.csv": late_start_date_expression_metric__expected_csv,
-        }
+            "same_period_and_grain__expected.csv": same_period_and_grain__expected_csv
+            }
 
     # everything that goes in the "models" directory
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "fact_orders.yml": fact_orders_yml,
-            "base_sum_metric.yml": base_sum_metric_yml,
-            "late_start_date_expression_metric.yml": late_start_date_expression_metric_yml,
             "fact_orders.sql": fact_orders_sql,
-            "late_start_date_expression_metric.sql": late_start_date_expression_metric_sql
+            "fact_orders.yml": fact_orders_yml,
+            "same_period_and_grain.sql": same_period_and_grain_sql,
+            "same_period_and_grain.yml": same_period_and_grain_yml
         }
 
     def test_build_completion(self,project,):
@@ -128,6 +153,6 @@ class TestStartDateExpressionMetric:
         results = run_dbt(["test"]) # expect passing test
         assert len(results) == 1
 
-        # # # # validate that the results include pass
+        # # # validate that the results include pass
         result_statuses = sorted(r.status for r in results)
         assert result_statuses == ["pass"]

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_sum.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_sum.py
@@ -102,6 +102,8 @@ else:
 class TestPeriodToDateSum:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_average.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_average.py
@@ -96,6 +96,8 @@ else:
 class TestRollingAverage:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count.py
@@ -100,6 +100,8 @@ else:
 class TestRollingCount:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count_distinct.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count_distinct.py
@@ -100,6 +100,8 @@ else:
 class TestRollingCountDistinct:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_expression.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_expression.py
@@ -113,6 +113,8 @@ else:
 class TestRollingExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_max.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_max.py
@@ -100,6 +100,8 @@ else:
 class TestRollingMax:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_min.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_min.py
@@ -100,6 +100,8 @@ else:
 class TestRollingMin:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_sum.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_sum.py
@@ -100,6 +100,8 @@ else:
 class TestRollingSum:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/start_date/test_late_start_date_base_metric.py
+++ b/tests/functional/metric_options/start_date/test_late_start_date_base_metric.py
@@ -51,6 +51,8 @@ date_month,late_start_date_base_sum_metric
 class TestLateStartDateBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/start_date/test_start_date_base_metric.py
+++ b/tests/functional/metric_options/start_date/test_start_date_base_metric.py
@@ -51,6 +51,8 @@ date_month,start_date_base_sum_metric
 class TestStartDateBaseSumMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/start_date/test_start_date_expression_metric.py
+++ b/tests/functional/metric_options/start_date/test_start_date_expression_metric.py
@@ -66,6 +66,8 @@ date_month,base_sum_metric,start_date_expression_metric
 class TestStartDateExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/where/test_where_base_metric.py
+++ b/tests/functional/metric_options/where/test_where_base_metric.py
@@ -1,0 +1,117 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/where_base_metric.sql
+where_base_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('where_base_metric'), 
+    grain='month',
+    dimensions=['had_discount'],
+    where=["had_discount=true"]
+    )
+}}
+"""
+
+# models/where_base_metric.yml
+where_base_metric_yml = """
+version: 2 
+models:
+  - name: where_base_metric
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('where_base_metric__expected')
+metrics:
+  - name: where_base_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/where_base_metric__expected.csv
+where_base_metric__expected_csv = """
+date_month,had_discount,where_base_metric
+2022-01-01,TRUE,2
+2022-02-01,TRUE,4
+""".lstrip()
+
+class TestWhereBaseMetric:
+
+    # configuration in dbt_project.yml
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "where_base_metric__expected.csv": where_base_metric__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "where_base_metric.sql": where_base_metric_sql,
+            "where_base_metric.yml": where_base_metric_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]

--- a/tests/functional/metric_options/where/test_where_base_metric.py
+++ b/tests/functional/metric_options/where/test_where_base_metric.py
@@ -17,7 +17,7 @@ from
 {{ metrics.calculate(metric('where_base_metric'), 
     grain='month',
     dimensions=['had_discount'],
-    where=["had_discount=true"]
+    where="had_discount=true"
     )
 }}
 """

--- a/tests/functional/metric_options/where/test_where_base_metric.py
+++ b/tests/functional/metric_options/where/test_where_base_metric.py
@@ -53,6 +53,8 @@ date_month,had_discount,where_base_metric
 class TestWhereBaseMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/where/test_where_expression_metric.py
+++ b/tests/functional/metric_options/where/test_where_expression_metric.py
@@ -68,6 +68,8 @@ date_month,had_discount,base_sum_metric,where_expression_metric
 class TestWhereExpressionMetric:
 
     # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
     if os.getenv('dbt_target') == 'bigquery':
         @pytest.fixture(scope="class")
         def project_config_update(self):

--- a/tests/functional/metric_options/where/test_where_expression_metric.py
+++ b/tests/functional/metric_options/where/test_where_expression_metric.py
@@ -17,7 +17,7 @@ from
 {{ metrics.calculate(metric('where_expression_metric'), 
     grain='month',
     dimensions=['had_discount'],
-    where=["had_discount=true"]
+    where="had_discount=true"
     )
 }}
 """

--- a/tests/functional/metric_options/where/test_where_expression_metric.py
+++ b/tests/functional/metric_options/where/test_where_expression_metric.py
@@ -1,0 +1,133 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/where_expression_metric.sql
+where_expression_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('where_expression_metric'), 
+    grain='month',
+    dimensions=['had_discount'],
+    where=["had_discount=true"]
+    )
+}}
+"""
+
+# models/base_sum_metric.yml
+base_sum_metric_yml = """
+version: 2 
+metrics:
+  - name: base_sum_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# models/where_expression_metric.yml
+where_expression_metric_yml = """
+version: 2 
+models:
+  - name: where_expression_metric
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('where_expression_metric__expected')
+metrics:
+  - name: where_expression_metric
+    label: Expression ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: expression
+    sql: "{{metric('base_sum_metric')}} + 1"
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/where_expression_metric__expected.csv
+where_expression_metric__expected_csv = """
+date_month,had_discount,base_sum_metric,where_expression_metric
+2022-01-01,TRUE,2,3
+2022-02-01,TRUE,4,5
+""".lstrip()
+
+class TestWhereExpressionMetric:
+
+    # configuration in dbt_project.yml
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "where_expression_metric__expected.csv": where_expression_metric__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.yml": fact_orders_yml,
+            "base_sum_metric.yml": base_sum_metric_yml,
+            "where_expression_metric.yml": where_expression_metric_yml,
+            "fact_orders.sql": fact_orders_sql,
+            "where_expression_metric.sql": where_expression_metric_sql
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
### Hotifixing The Where
Originally added in #34 , it was quickly identified by @joellabes that the `where` clause was not aligned with the vision of metrics - its flexibility broke the ideal constrained nature of metrics. As such, we opened #42 to address what the future of this parameter would look like. **There are still open discussions there**.

In the meantime, this Hotfix moves the `where` to the end of the generated SQL so that it can no longer be used in the non-ideal way. We may choose to move some of the filtering logic to the base query in the future for performance reasons but that would require more validation of the where clauses. This hotfix does not address that.

### Changes:
- Removed `where` from all macros where it previously existed
- Added `where` to `gen_final_cte` and apply it there
- Added 3 tests in pytest to confirm functionality:
  - test_invalid_where: confirms that a column that isn't provided in the final cte cannot be used in `where`
  - test_where_base_metric: confirms that `where` works for base metrics (non-expression)
  - test_where_expression_metric: confirms that `where` works for expression metrics 