### PR TITLE
docs: update 'where' in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ from {{ metrics.calculate(
     ],
     start_date='2022-01-01',
     end_date='2022-12-31',
-    where=["some_column='filter_value'"]
+    where="some_column='filter_value'"
 ) }}
 ```
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Updating the example to reflect the changes to the where parameter in v0.3.0.
> From v0.3.0 onwards, the where clause takes a single string, not a list of filters.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
