### PR TITLE
Ensuring Numeric Output Data Tests

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "dbt_metrics_integration_tests_bigquery"
+profile: "dbt_metrics_integration_tests"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/tests/functional/invalid_configs/test_invalid_date_datatype.py
+++ b/tests/functional/invalid_configs/test_invalid_date_datatype.py
@@ -1,0 +1,82 @@
+from configparser import ParsingError
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+from dbt.exceptions import CompilationException, ParsingException
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/max_date_invalid_datatype.sql
+max_date_invalid_datatype_sql = """
+select *
+from 
+{{ metrics.calculate(metric('max_date_invalid_datatype'), 
+    grain='day'
+    )
+}}
+"""
+
+# models/invalid_metric_names.yml
+invalid_metric_names_yml = """
+version: 2 
+
+metrics:
+  - name: max_date_invalid_datatype
+    model: ref('fact_orders')
+    label: max_date_invalid_datatype
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: max
+    sql: order_date
+"""
+
+class TestInvalidDatatypes:
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv
+            }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "max_date_invalid_datatype.sql": max_date_invalid_datatype_sql,
+            "invalid_metric_names.yml": invalid_metric_names_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+        results = run_dbt(["seed"])
+
+        # initial run
+        results = run_dbt(["run"],expect_pass = False)

--- a/tests/functional/invalid_configs/test_invalid_string_datatype.py
+++ b/tests/functional/invalid_configs/test_invalid_string_datatype.py
@@ -1,0 +1,82 @@
+from configparser import ParsingError
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+from dbt.exceptions import CompilationException, ParsingException
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/max_string_invalid_datatype.sql
+max_string_invalid_datatype_sql = """
+select *
+from 
+{{ metrics.calculate(metric('max_string_invalid_datatype'), 
+    grain='day'
+    )
+}}
+"""
+
+# models/invalid_metric_names.yml
+invalid_metric_names_yml = """
+version: 2 
+
+metrics:
+  - name: max_string_invalid_datatype
+    model: ref('fact_orders')
+    label: max_date_invalid_datatype
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: max
+    sql: order_country
+"""
+
+class TestInvalidStringDataType:
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv
+            }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "max_string_invalid_datatype.sql":max_string_invalid_datatype_sql,
+            "invalid_metric_names.yml": invalid_metric_names_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+        results = run_dbt(["seed"])
+
+        # initial run
+        results = run_dbt(["run"],expect_pass = False)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
We've heard from our partners that ensuring that the data produced by the macro is in the correct datatype is key for visualization. Most importantly, the metric field needs to be numeric. Relevant issue here: #76

This PR adds two tests to ensure that this behavior is consistent and that min/max metrics on string or date datatypes won't return those values. 

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
