### PR TITLE
update string parsing to accomodate double quotes

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -112,7 +112,7 @@ metrics there are #}
 
     {% for metric_name in metric_tree["parent_set"]%}
         {%- set loop_metric = metrics.get_metric_relation(metric_name) -%}
-        {%- set loop_base_model = loop_metric.model.split('\'')[1]  -%}
+        {%- set loop_base_model = loop_metric.model.replace('"','\'').split('\'')[1]  -%}
         {%- set loop_model = metrics.get_model_relation(loop_base_model if execute else "") %}
         {{ metrics.build_metric_sql(loop_metric, loop_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date,calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
     {% endfor %}
@@ -129,7 +129,7 @@ metrics there are #}
 
     {% for metric_name in metric_tree["full_set"]%}
         {%- set single_metric = metric(metric_name) -%}
-        {%- set single_base_model = single_metric.model.split('\'')[1]  -%}
+        {%- set single_base_model = single_metric.model.replace('"','\'').split('\'')[1]  -%}
         {%- set single_model = metrics.get_model_relation(single_base_model if execute else "") %}
         {{ metrics.build_metric_sql(single_metric, single_model, grain, non_calendar_dimensions, secondary_calculations, start_date, end_date, calendar_tbl, relevant_periods, calendar_dimensions,dimensions_provided) }}
     {% endfor %}

--- a/tests/functional/metric_options/metric_reference/test_double_quote_ref_name.py
+++ b/tests/functional/metric_options/metric_reference/test_double_quote_ref_name.py
@@ -1,0 +1,122 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/double_quote_ref_metrics.sql
+double_quote_ref_metrics_sql = """
+select *
+from 
+{{ metrics.calculate(
+    metric('base_count_metric'),
+    grain='month',
+    dimensions=['had_discount']
+    )
+}}
+"""
+
+# models/double_quote_ref_metrics.yml
+double_quote_ref_metrics_yml = """
+version: 2 
+models:
+  - name: double_quote_ref_metrics
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('double_quote_ref_metrics__expected')
+metrics:
+  - name: base_count_metric
+    model: ref("fact_orders")
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: count
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+
+"""
+
+# seeds/double_quote_ref_metrics__expected.csv
+double_quote_ref_metrics__expected_csv = """
+date_month,had_discount,base_count_metric
+2022-01-01,TRUE,2
+2022-01-01,FALSE,5
+2022-02-01,TRUE,1
+2022-02-01,FALSE,2
+""".lstrip()
+
+class TestDoubleQuoteRefMetrics:
+
+    # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "double_quote_ref_metrics__expected.csv": double_quote_ref_metrics__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "double_quote_ref_metrics.sql": double_quote_ref_metrics_sql,
+            "double_quote_ref_metrics.yml": double_quote_ref_metrics_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

Closes #75 

This PR updates the string parsing logic that resolves the model key in a metric yml config to properly return the model name if the user writes the ref with double quotes (an acceptable way to use the ref function). 

This logic first replaces double quotes with single quotes before the macro parses that value to return the name of the model that the metric depends on. 

Screenshot of the raw model entry, followed by the parsed model name after the change:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/73915542/183963450-e2087900-d653-4357-9320-18f85082424e.png">

I tested this with one single metric and a list of two metrics returned by the `metrics.calculate` macro!

Feels a little rough to me, but curious for feedback!

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
