### PR TITLE
Removing dbt_utils Type Float dependency

### DIFF
--- a/macros/secondary_calculations/secondary_calculation_period_over_period.sql
+++ b/macros/secondary_calculations/secondary_calculation_period_over_period.sql
@@ -28,7 +28,7 @@
 {% endmacro %}
 
 {% macro default__metric_comparison_strategy_ratio(metric_name, calc_sql) %}
-    cast(coalesce({{ metric_name }}, 0) as {{ dbt_utils.type_float() }}) / nullif({{ calc_sql }}, 0) 
+    cast(coalesce({{ metric_name }}, 0) as {{ type_float() }}) / nullif({{ calc_sql }}, 0) 
 {% endmacro %}
 
 {% macro period_over_period(comparison_strategy, interval, alias) %}


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Based on the comments from @dbeatty10 in #62 , we are removing the `dbt_utils` identifier around `type_float` because it is moving into the `dbt-core` repo instead of `dbt_utils`

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
