### PR TITLE
Removing model introspection and adding allow_calendar_dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,20 @@ vars:
 ```
 
 ### Dimensions from calendar tables
-You may want to aggregate metrics by a dimension in your custom calendar table, for example `is_weekend`. You can include this within the list of `dimensions` in the macro call **without** it needing to be defined in the metric definition. The macro will correctly recognize that it is coming from the calendar dimension and treat it accordingly.
+You may want to aggregate metrics by a dimension in your custom calendar table, for example `is_weekend`. You can include this within the list of `dimensions` in the macro call **without** it needing to be defined in the metric definition. 
+
+To do so, set the `allow_calendar_dimensions` parameter of the macro to true. This will allow columns from the calendar dimension to be included in the dimension list. See example below:
+
+```sql
+  select *
+  from 
+  {{ metrics.calculate(
+      metric('base_sum_metric'), 
+      grain='day', 
+      dimensions=['is_weekend'],
+      allow_calendar_dimensions=true
+  }}
+```
 
 ## Time Grains 
 The package protects against nonsensical secondary calculations, such as a month-to-date aggregate of data which has been rolled up to the quarter. If you customise your calendar (for example by adding a [4-5-4 retail calendar](https://calogica.com/sql/dbt/2018/11/15/retail-calendar-in-sql.html) month), you will need to override the [`get_grain_order()`](/macros/secondary_calculations/validate_grain_order.sql) macro. In that case, you might remove `month` and replace it with `month_4_5_4`. All date columns must be prefixed with `date_` in the table. Do not include the prefix when defining your metric, it will be added automatically.

--- a/README.md
+++ b/README.md
@@ -226,18 +226,14 @@ vars:
 ### Dimensions from calendar tables
 You may want to aggregate metrics by a dimension in your custom calendar table, for example `is_weekend`. You can include this within the list of `dimensions` in the macro call **without** it needing to be defined in the metric definition. 
 
-To do so, set the `allow_calendar_dimensions` parameter of the macro to true. This will allow columns from the calendar dimension to be included in the dimension list. See example below:
+To do so, set a list variable at the project level called `custom_calendar_dimension_list`, as shown in the example below.
 
-```sql
-  select *
-  from 
-  {{ metrics.calculate(
-      metric('base_sum_metric'), 
-      grain='day', 
-      dimensions=['is_weekend'],
-      allow_calendar_dimensions=true
-  }}
+```yml
+vars:
+  custom_calendar_dimension_list: ["is_weekend"]
 ```
+
+The `is_weekend` field can now be used by your metrics. 
 
 ## Time Grains 
 The package protects against nonsensical secondary calculations, such as a month-to-date aggregate of data which has been rolled up to the quarter. If you customise your calendar (for example by adding a [4-5-4 retail calendar](https://calogica.com/sql/dbt/2018/11/15/retail-calendar-in-sql.html) month), you will need to override the [`get_grain_order()`](/macros/secondary_calculations/validate_grain_order.sql) macro. In that case, you might remove `month` and replace it with `month_4_5_4`. All date columns must be prefixed with `date_` in the table. Do not include the prefix when defining your metric, it will be added automatically.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
    * [Secondary calculation column aliases](#secondary-calculation-column-aliases)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: runner, at: Mon Aug 22 18:30:20 UTC 2022 -->
+<!-- Added by: runner, at: Mon Aug 22 21:45:24 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
    * [Secondary calculation column aliases](#secondary-calculation-column-aliases)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: runner, at: Thu Aug 18 14:11:59 UTC 2022 -->
+<!-- Added by: runner, at: Mon Aug 22 18:30:20 UTC 2022 -->
 
 <!--te-->
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -28,4 +28,4 @@ models:
 
 vars:
   dbt_metrics_calendar_model: custom_calendar
-  testing: fact_orders
+  custom_calendar_dimension_list: ["is_weekend"]

--- a/integration_tests/models/metric_testing_models/base_sum_metric.sql
+++ b/integration_tests/models/metric_testing_models/base_sum_metric.sql
@@ -3,5 +3,5 @@ from
 {{ metrics.calculate(
     metric('base_sum_metric'), 
     grain='day', 
-    dimensions=['had_discount']) 
+    dimensions=['had_discount','is_weekend']) 
 }}

--- a/integration_tests/models/metric_testing_models/expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/expression_metric.sql
@@ -5,5 +5,6 @@ from
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',
-    end_date = '2022-01-10') 
+    end_date = '2022-01-10',
+    allow_calendar_dimensions=True) 
 }}

--- a/integration_tests/models/metric_testing_models/expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/expression_metric.sql
@@ -5,6 +5,6 @@ from
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',
-    end_date = '2022-01-10',
-    allow_calendar_dimensions=True) 
+    end_date = '2022-01-10'
+    ) 
 }}

--- a/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
@@ -5,6 +5,6 @@ from
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',
-    end_date = '2022-01-05',
-    allow_calendar_dimensions = True) 
+    end_date = '2022-01-05'
+    ) 
 }}

--- a/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
@@ -6,5 +6,6 @@ from
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',
     end_date = '2022-01-05'
+    
     ) 
 }}

--- a/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
+++ b/integration_tests/models/metric_testing_models/metric_on_expression_metric.sql
@@ -5,5 +5,6 @@ from
     grain='day', 
     dimensions=['had_discount','order_country','is_weekend'],
     start_date = '2022-01-01',
-    end_date = '2022-01-05') 
+    end_date = '2022-01-05',
+    allow_calendar_dimensions = True) 
 }}

--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -1,9 +1,9 @@
-{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
-    {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, allow_calendar_dimensions)) }}
+{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
+    {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
 {% endmacro %}
 
 
-{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
+{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 
@@ -24,7 +24,7 @@
     {# We have to break out calendar dimensions as their own list of acceptable dimensions. 
     This is because of the date-spining. If we don't do this, it creates impossible combinations
     of calendar dimension + base dimensions #}
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
+    {%- set calendar_dimensions = metrics.get_calendar_dimension_list() -%}
 
     {# Additionally, we also have to restrict the dimensions coming in from the macro to 
     no longer include those we've designated as calendar dimensions. That way they 
@@ -60,7 +60,7 @@
 
     {% do metrics.validate_expression_metrics(metric_tree['full_set'])%}
 
-    {% do metrics.validate_dimension_list(dimensions, metric_tree['full_set'], calendar_dimensions, allow_calendar_dimensions) %}
+    {% do metrics.validate_dimension_list(dimensions, metric_tree['full_set'], calendar_dimensions) %}
 
     {# ############
     SECONDARY CALCULATION VALIDATION - Let there be window functions

--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -1,9 +1,9 @@
-{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
-    {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
+{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
+    {{ return(adapter.dispatch('calculate', 'metrics')(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, allow_calendar_dimensions)) }}
 {% endmacro %}
 
 
-{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
+{% macro default__calculate(metric_list, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 
@@ -19,7 +19,8 @@
         start_date=start_date,
         end_date=end_date,
         where=where,
-        initiated_by='calculate'
+        initiated_by='calculate',
+        allow_calendar_dimensions=allow_calendar_dimensions
     ) %}
     ({{ sql }}) metric_subq
 {%- endmacro %}

--- a/macros/develop.sql
+++ b/macros/develop.sql
@@ -1,9 +1,9 @@
-{% macro develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
-    {{ return(adapter.dispatch('develop', 'metrics')(develop_yml, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
+{% macro develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
+    {{ return(adapter.dispatch('develop', 'metrics')(develop_yml, grain, dimensions, secondary_calculations, start_date, end_date, where, allow_calendar_dimensions)) }}
 {% endmacro %}
 
 
-{% macro default__develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
+{% macro default__develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 
@@ -11,11 +11,12 @@
         {%- do return("not execute") %}
     {%- endif %}
     
+    {% set develop_yml = fromyaml(develop_yml)%}
+
     {# ############
     VALIDATION OF PROVIDED YML
     ############ #}
-    {% set develop_yml = fromyaml(develop_yml) %}
-
+    
     {% if develop_yml["metrics"] | length > 1%}
         {%- do exceptions.raise_compiler_error("The develop macro only supports testing a single macro.") %}
     {% endif %}
@@ -73,7 +74,8 @@
         end_date=end_date,
         where=where,
         initiated_by='develop',
-        metric_definition=metric_definition
+        metric_definition=metric_definition,
+        allow_calendar_dimensions=allow_calendar_dimensions
     ) %}
     ({{ sql }}) metric_subq
 {%- endmacro %}

--- a/macros/develop.sql
+++ b/macros/develop.sql
@@ -1,9 +1,9 @@
-{% macro develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
-    {{ return(adapter.dispatch('develop', 'metrics')(develop_yml, grain, dimensions, secondary_calculations, start_date, end_date, where, allow_calendar_dimensions)) }}
+{% macro develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
+    {{ return(adapter.dispatch('develop', 'metrics')(develop_yml, grain, dimensions, secondary_calculations, start_date, end_date, where)) }}
 {% endmacro %}
 
 
-{% macro default__develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None, allow_calendar_dimensions=False) -%}
+{% macro default__develop(develop_yml, grain, dimensions=[], secondary_calculations=[], start_date=None, end_date=None, where=None) -%}
     -- Need this here, since the actual ref is nested within loops/conditions:
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
 
@@ -93,7 +93,7 @@
     VARIABLES FOR SQL GEN - More variables we need for sql gen
     ############ #}
 
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
+    {%- set calendar_dimensions = metrics.get_calendar_dimension_list() -%}
     {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions,calendar_dimensions) -%}
     {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
 

--- a/macros/develop.sql
+++ b/macros/develop.sql
@@ -90,6 +90,14 @@
     {%- endfor %}
 
     {# ############
+    VARIABLES FOR SQL GEN - More variables we need for sql gen
+    ############ #}
+
+    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
+    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions,calendar_dimensions) -%}
+    {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
+
+    {# ############
     SQL GENERATION - Lets build that SQL!
     ############ #}
 
@@ -104,7 +112,9 @@
         initiated_by='develop',
         metric_definition=metric_definition,
         metric_tree=metric_tree,
-        allow_calendar_dimensions=allow_calendar_dimensions
-    ) %}
+        calendar_dimensions=calendar_dimensions,
+        non_calendar_dimensions=non_calendar_dimensions,
+        relevant_periods=relevant_periods
+        ) %}
     ({{ sql }}) metric_subq
 {%- endmacro %}

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -4,7 +4,7 @@
       - allow start/end dates on metrics. Maybe special-case "today"?
       - allow passing in a seed with targets for a metric's value
 */
-{%- macro get_metric_sql(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, initiated_by,metric_definition=None) %}
+{%- macro get_metric_sql(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, initiated_by, allow_calendar_dimensions, metric_definition=None) %}
 
 {# ############
 VALIDATION AROUND METRIC VS CALCULATE VS DEVELOP
@@ -98,25 +98,26 @@ a custom calendar #}
 {%- set calendar_tbl = ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar")) %}
 
 {% if is_develop_macro %}
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(metric_dimensions, dimensions) -%}
-    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions) -%}
+    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
+    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions,calendar_dimensions) -%}
     {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
 
 {% else %}
-    {# Here we are creating a list of all valid dimensions, as well as providing compilation
-    errors if there are any provided dimensions that don't work. #}
-    {% set common_valid_dimension_list = metrics.get_common_valid_dimension_list(dimensions, metric_tree['full_set']) %}
 
     {# We have to break out calendar dimensions as their own list of acceptable dimensions. 
     This is because of the date-spining. If we don't do this, it creates impossible combinations
     of calendar dimension + base dimensions #}
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, common_valid_dimension_list) -%}
+    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
+
+    {# Here we are creating a list of all valid dimensions, as well as providing compilation
+    errors if there are any provided dimensions that don't work. #}
+    {% set common_valid_dimension_list = metrics.get_common_valid_dimension_list(dimensions, metric_tree['full_set'], calendar_dimensions, allow_calendar_dimensions) %}
 
     {# Additionally, we also have to restrict the dimensions coming in from the macro to 
     no longer include those we've designated as calendar dimensions. That way they 
     are correctly handled by the spining. We override the dimensions variable for 
     cleanliness #}
-    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions) -%}
+    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions, calendar_dimensions) -%}
 
     {# Finally we set the relevant periods, which is a list of all time grains that need to be contained
     within the final dataset in order to accomplish base + secondary calc functionality. #}

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -4,7 +4,7 @@
       - allow start/end dates on metrics. Maybe special-case "today"?
       - allow passing in a seed with targets for a metric's value
 */
-{%- macro get_metric_sql(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, initiated_by, metric_tree, allow_calendar_dimensions, metric_definition=None) %}
+{%- macro get_metric_sql(metric_list, grain, dimensions, secondary_calculations, start_date, end_date, where, initiated_by, metric_tree, calendar_dimensions, non_calendar_dimensions, relevant_periods, metric_definition=None) %}
 
 {# ############
 VALIDATION AROUND METRIC VS CALCULATE VS DEVELOP
@@ -48,34 +48,6 @@ LETS SET SOME VARIABLES AND VALIDATE!
 {# Here we set the calendar table as a variable, which ensures the default overwritten if they include
 a custom calendar #}
 {%- set calendar_tbl = ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar")) %}
-
-{% if is_develop_macro %}
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
-    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions,calendar_dimensions) -%}
-    {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
-
-{% else %}
-
-    {# We have to break out calendar dimensions as their own list of acceptable dimensions. 
-    This is because of the date-spining. If we don't do this, it creates impossible combinations
-    of calendar dimension + base dimensions #}
-    {%- set calendar_dimensions = metrics.get_calendar_dimension_list(dimensions, allow_calendar_dimensions) -%}
-
-    {# Here we are creating a list of all valid dimensions, as well as providing compilation
-    errors if there are any provided dimensions that don't work. #}
-    {% set common_valid_dimension_list = metrics.get_common_valid_dimension_list(dimensions, metric_tree['full_set'], calendar_dimensions, allow_calendar_dimensions) %}
-
-    {# Additionally, we also have to restrict the dimensions coming in from the macro to 
-    no longer include those we've designated as calendar dimensions. That way they 
-    are correctly handled by the spining. We override the dimensions variable for 
-    cleanliness #}
-    {%- set non_calendar_dimensions = metrics.get_non_calendar_dimension_list(dimensions, calendar_dimensions) -%}
-
-    {# Finally we set the relevant periods, which is a list of all time grains that need to be contained
-    within the final dataset in order to accomplish base + secondary calc functionality. #}
-    {%- set relevant_periods = metrics.get_relevent_periods(grain, secondary_calculations) %}
-
-{% endif %}
 
 {# ############
 LET THE COMPOSITION BEGIN!

--- a/macros/validation/validate_dimension_list.sql
+++ b/macros/validation/validate_dimension_list.sql
@@ -22,7 +22,7 @@
                 {% if allow_calendar_dimensions %}
                     {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name) %}
                 {% else %}
-                    {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name ~ ". If the dimension is from the calendar table, please set allow_calendar_dimensions = True in the macro.") %}
+                    {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name ~ ". If the dimension is from a custom calendar table, please create the custom_calendar_dimension_list as shown in the README.") %}
                 {% endif %}
             {% endif %}
 

--- a/macros/validation/validate_dimension_list.sql
+++ b/macros/validation/validate_dimension_list.sql
@@ -1,19 +1,11 @@
-{% macro get_common_valid_dimension_list(dimensions, metric_names, calendar_dimensions, allow_calendar_dimensions) %}
+{% macro validate_dimension_list(dimensions, metric_names, calendar_dimensions, allow_calendar_dimensions) %}
     
     {# This macro exists to invalidate dimensions provided to the metric macro that are not viable 
     candidates based on metric definitions. This prevents downstream run issues when the sql 
     logic attempts to group by provided dimensions and fails because they don't exist for 
     one or more of the required metrics. #}
 
-    {# First we create an empty dictionary to store information as we loop through 
-    the dimension provided in the macro #}
-    {% set common_valid_dimension_dict = {} %}
     {% for dim in dimensions %}
-
-        {# We create a base key value pair in the dictionary that has a base value of 0.
-        This value is later used downstream to match the number of metrics in the full set
-        and only include the dimension if the counts match #}
-        {% do common_valid_dimension_dict.update({dim:0})%}
 
         {# Now we loop through all the metrics in the full set, which is all metrics, parent metrics,
         and expression metrics associated with the macro call #}
@@ -32,24 +24,9 @@
                 {% else %}
                     {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name ~ ". If the dimension is from the calendar table, please set allow_calendar_dimensions = True in the macro.") %}
                 {% endif %}
-            {% else %}
-                {# Here we update the value of the dictionary value to be + 1 to the previous value #}
-                {% set new_dim_value = common_valid_dimension_dict[dim] + 1 %}
-                {% do common_valid_dimension_dict.update({dim:new_dim_value})%}
             {% endif %}
 
         {%endfor%}
     {%endfor%}
-
-    {# We create an empty list that we later return at the end of the macro #}
-    {% set common_valid_dimension_list = [] %}
-    {# Now we iterate through the dictionary and create a list that contains the 
-    dimensions that have not raised compilation errors. #}
-    {% for key, value in common_valid_dimension_dict.items() %}
-            {% do common_valid_dimension_list.append(key) %}
-    {% endfor %}
-
-    {# Return the list!  #}
-    {% do return(common_valid_dimension_list) %}
 
 {% endmacro %}

--- a/macros/variables/get_calendar_dimension_list.sql
+++ b/macros/variables/get_calendar_dimension_list.sql
@@ -1,19 +1,25 @@
-{% macro get_calendar_dimension_list(dimensions,dimension_list) %}
+{% macro get_calendar_dimension_list(dimensions, allow_calendar_dimensions) %}
     
-    {% set calendar_dims = dbt_utils.get_filtered_columns_in_relation(from=ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar"))) %}
-    {% set calendar_dimensions = [] %}
-    {% for dim in calendar_dims %}
-        {% do calendar_dimensions.append(dim | lower) %}
-    {% endfor %}
+    {% if allow_calendar_dimensions %}
+        {% set calendar_dims = dbt_utils.get_filtered_columns_in_relation(from=ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar"))) %}
+        {% set calendar_dimensions = [] %}
+        {% for dim in calendar_dims %}
+            {% do calendar_dimensions.append(dim | lower) %}
+        {% endfor %}
 
-    {# Here we set the calendar as either being the default provided by the package
-    or the variable provided in the project #}
-    {% set approved_calendar_dimensions = [] %}
-    {% for dim in dimensions %}
-        {%- if dim in calendar_dimensions -%}
-            {%- do approved_calendar_dimensions.append(dim | lower) -%}
-        {%- endif -%}
-    {% endfor %}
-    {%- do return(approved_calendar_dimensions) -%}
+        {# Here we set the calendar as either being the default provided by the package
+        or the variable provided in the project #}
+        {% set approved_calendar_dimensions = [] %}
+        {% for dim in dimensions %}
+            {%-if dim in calendar_dimensions %}
+                {% do approved_calendar_dimensions.append(dim | lower) %}
+            {% endif -%}
+        {% endfor %}
+        {% do return(approved_calendar_dimensions) %}
+
+    {% else %}
+        {% set empty_calendar_dimensions = [] %}
+        {% do return(empty_calendar_dimensions) %}
+    {% endif %}
 
 {% endmacro %}

--- a/macros/variables/get_calendar_dimension_list.sql
+++ b/macros/variables/get_calendar_dimension_list.sql
@@ -1,25 +1,6 @@
-{% macro get_calendar_dimension_list(dimensions, allow_calendar_dimensions) %}
+{% macro get_calendar_dimension_list() %}
     
-    {% if allow_calendar_dimensions %}
-        {% set calendar_dims = dbt_utils.get_filtered_columns_in_relation(from=ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar"))) %}
-        {% set calendar_dimensions = [] %}
-        {% for dim in calendar_dims %}
-            {% do calendar_dimensions.append(dim | lower) %}
-        {% endfor %}
-
-        {# Here we set the calendar as either being the default provided by the package
-        or the variable provided in the project #}
-        {% set approved_calendar_dimensions = [] %}
-        {% for dim in dimensions %}
-            {%-if dim in calendar_dimensions %}
-                {% do approved_calendar_dimensions.append(dim | lower) %}
-            {% endif -%}
-        {% endfor %}
-        {% do return(approved_calendar_dimensions) %}
-
-    {% else %}
-        {% set empty_calendar_dimensions = [] %}
-        {% do return(empty_calendar_dimensions) %}
-    {% endif %}
+    {% set calendar_dimensions = var('custom_calendar_dimension_list',[]) %}
+    {% do return(calendar_dimensions) %}
 
 {% endmacro %}

--- a/macros/variables/get_common_valid_dimension_list.sql
+++ b/macros/variables/get_common_valid_dimension_list.sql
@@ -1,4 +1,4 @@
-{% macro get_common_valid_dimension_list(dimensions, metric_names) %}
+{% macro get_common_valid_dimension_list(dimensions, metric_names, calendar_dimensions, allow_calendar_dimensions) %}
     
     {# This macro exists to invalidate dimensions provided to the metric macro that are not viable 
     candidates based on metric definitions. This prevents downstream run issues when the sql 
@@ -21,13 +21,17 @@
             {% set metric_relation = metric(metric_name)%}
             
             {# This macro returns a list of dimensions that are inclusive of calendar dimensions #}
-            {% set complete_dimension_list = metrics.get_complete_dimension_list(metric_relation)%}
+            {% set complete_dimension_list = metrics.get_complete_dimension_list(metric_relation, calendar_dimensions) %}
 
             {# If the dimension provided is not present in the loop metrics dimension list then we 
             will raise an error. If it is missing in ANY of the metrics, it cannot be used in the 
             macro call. Only dimensions that are valid in all metrics are valid in the macro call #}
             {% if dim not in complete_dimension_list %}
-                {%- do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name) %}
+                {% if allow_calendar_dimensions %}
+                    {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name) %}
+                {% else %}
+                    {% do exceptions.raise_compiler_error("The dimension " ~ dim ~ " is not part of the metric " ~ metric_relation.name ~ ". If the dimension is from the calendar table, please set allow_calendar_dimensions = True in the macro.") %}
+                {% endif %}
             {% else %}
                 {# Here we update the value of the dictionary value to be + 1 to the previous value #}
                 {% set new_dim_value = common_valid_dimension_dict[dim] + 1 %}

--- a/macros/variables/get_complete_dimension_list.sql
+++ b/macros/variables/get_complete_dimension_list.sql
@@ -1,13 +1,8 @@
-{% macro get_complete_dimension_list(metric) %}
+{% macro get_complete_dimension_list(metric, calendar_dimensions) %}
     
     {# Here we set the calendar as either being the default provided by the package
     or the variable provided in the project #}
-    {% set calendar_dims = dbt_utils.get_filtered_columns_in_relation(from=ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar"))) %}
-
-    {% set calendar_dimensions = [] %}
-    {% for dim in calendar_dims %}
-        {% do calendar_dimensions.append(dim | lower) %}
-    {% endfor %}
+    {% set calendar_dims = calendar_dimensions %}
 
     {# Here we are going to ensure that the metrics provided are accurate and that they are present 
     in either the metric definition or the default/custom calendar table #}

--- a/macros/variables/get_non_calendar_dimension_list.sql
+++ b/macros/variables/get_non_calendar_dimension_list.sql
@@ -1,10 +1,6 @@
-{% macro get_non_calendar_dimension_list(dimensions) %}
+{% macro get_non_calendar_dimension_list(dimensions,calendar_dimensions) %}
     
-    {% set calendar_dims = dbt_utils.get_filtered_columns_in_relation(from=ref(var('dbt_metrics_calendar_model', "dbt_metrics_default_calendar"))) %}
-    {% set calendar_dimensions = [] %}
-    {% for dim in calendar_dims %}
-        {% do calendar_dimensions.append(dim | lower) %}
-    {% endfor %}
+    {% set calendar_dims = calendar_dimensions %}
 
     {# Here we set the calendar as either being the default provided by the package
     or the variable provided in the project #}

--- a/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
+++ b/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
@@ -1,0 +1,99 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/invalid_calendar_dim_without_param.sql
+invalid_calendar_dim_without_param_sql = """
+select *
+from 
+{{ metrics.calculate(metric('invalid_calendar_dim_without_param'), 
+    grain='month',
+    dimensions=['date_year']
+    )
+}}
+"""
+
+# models/invalid_calendar_dim_without_param.yml
+invalid_calendar_dim_without_param_yml = """
+version: 2 
+models:
+  - name: invalid_calendar_dim_without_param
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('invalid_calendar_dim_without_param__expected')
+metrics:
+  - name: invalid_calendar_dim_without_param
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+
+class TestInvalidCalendarDimensionWithoutParameter:
+
+    # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "invalid_calendar_dim_without_param.sql": invalid_calendar_dim_without_param_sql,
+            "invalid_calendar_dim_without_param.yml": invalid_calendar_dim_without_param_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+        results = run_dbt(["seed"])
+
+        # initial run
+        results = run_dbt(["run"],expect_pass = False)


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] documentation update
- [x] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Related to issue #85 , this PR removes the default behavior of running queries against the data warehouse to validate the input. The only part where this introduced issues was in the use of calendar dimensions in the macro call. 

To support this use case while improving performance, we added the `allow_calendar_dimensions` parameter into the macro that can be set to true if the individual wants to add calendar dimensions. The package will only run a filtered column relation query IF this is set to true and will now only run 1 instead of multiple per metric.

Example:
```sql
  select *
  from 
  {{ metrics.calculate(
      metric('base_sum_metric'), 
      grain='day', 
      dimensions=['is_weekend'],
      allow_calendar_dimensions=true
  }}
```

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
