### PR TITLE
Develop Model Validation

### DIFF
--- a/integration_tests/models/metric_testing_models/develop_metric.sql
+++ b/integration_tests/models/metric_testing_models/develop_metric.sql
@@ -2,7 +2,7 @@
 
 metrics:
   - name: develop_metric
-    model: ref('fact_orders')
+    model: ref('fact_orderss')
     label: Total Discount ($)
     timestamp: order_date
     time_grains: [day, week, month]

--- a/integration_tests/models/metric_testing_models/develop_metric.sql
+++ b/integration_tests/models/metric_testing_models/develop_metric.sql
@@ -2,7 +2,7 @@
 
 metrics:
   - name: develop_metric
-    model: ref('fact_orderss')
+    model: ref('fact_orders')
     label: Total Discount ($)
     timestamp: order_date
     time_grains: [day, week, month]

--- a/integration_tests/models/metric_testing_models/testing_metrics.sql
+++ b/integration_tests/models/metric_testing_models/testing_metrics.sql
@@ -1,6 +1,1 @@
-select *
-from 
-{{ metrics.calculate(metric('base_count_metric'), 
-    grain='week'
-    )
-}}
+select 1 as test

--- a/macros/graph_parsing/get_model_relation.sql
+++ b/macros/graph_parsing/get_model_relation.sql
@@ -1,13 +1,19 @@
-{% macro get_model_relation(ref_name) %}
+{% macro get_model_relation(ref_name, metric_name) %}
     {% if execute %}
         {% set model_ref_node = graph.nodes.values() | selectattr('name', 'equalto', ref_name) | first %}
+        {% if model_ref_node | length == 0 %}
+            {%- do exceptions.raise_compiler_error("The metric " ~ metric_name ~ " is referencing the model " ~ ref_name ~ ", which does not exist.") %}
+        {% endif %}
+
         {% set relation = api.Relation.create(
             database = model_ref_node.database,
             schema = model_ref_node.schema,
             identifier = model_ref_node.alias
         )
         %}
+        
         {% do return(relation) %}
+
     {% else %}
         {% do return(api.Relation.create()) %}
     {% endif %} 

--- a/macros/variables/get_develop_metrics_dictionary.sql
+++ b/macros/variables/get_develop_metrics_dictionary.sql
@@ -12,7 +12,8 @@
     {% do metrics_dictionary[metric].update({'dimensions':metric_definition["dimensions"]})%}
     {% do metrics_dictionary[metric].update({'filters':metric_definition["filters"]})%}
     {% do metrics_dictionary[metric].update({'metric_model_name':metric_definition["model"].replace('"','\'').split('\'')[1]})%}
-    {% do metrics_dictionary[metric].update({'metric_model':metrics.get_model_relation(metrics_dictionary[metric]['metric_model_name'])}) %}
+    {% do metrics_dictionary[metric].update({'metric_model':metrics.get_model_relation(metrics_dictionary[metric]['metric_model_name'], metrics_dictionary[metric]["name"])}) %}
+
 {% endfor %}
 
 {% do return(metrics_dictionary) %}

--- a/macros/variables/get_metrics_dictionary.sql
+++ b/macros/variables/get_metrics_dictionary.sql
@@ -17,7 +17,7 @@
 
     {% if dict_metric.type != 'expression' %}
         {% do metrics_dictionary[metric].update({'metric_model_name':dict_metric.model.replace('"','\'').split('\'')[1]})%}
-        {% do metrics_dictionary[metric].update({'metric_model':metrics.get_model_relation(metrics_dictionary[metric]['metric_model_name'])}) %}
+        {% do metrics_dictionary[metric].update({'metric_model':metrics.get_model_relation(metrics_dictionary[metric]['metric_model_name'], metrics_dictionary[metric]['name'])}) %}
     {% endif %}
 
 {% endfor %}

--- a/tests/functional/invalid_configs/develop/test_invalid_develop_config__invalid_model.py
+++ b/tests/functional/invalid_configs/develop/test_invalid_develop_config__invalid_model.py
@@ -77,4 +77,5 @@ class TestDevelopMetricDimension:
         results = run_dbt(["seed"])
 
         # initial run
-        results = run_dbt(["run"],expect_pass = False)
+        results = run_dbt(["run"],expect_pass = False) 
+        


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
If you use a model that doesn't exist with the `develop` macro it throws a very confusing empty list error that doesn't help the user debug at all. This PR adds extra validation to the `get_model_relation` macro that confirms that the model exists and surfaces an appropriate error message if it doesn't. Something like this:
> The metric develop_metric is referencing the model fact_orderssss, which does not exist.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
