### PR TITLE
Let there be all time

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ Constructor: `metrics.rolling(aggregate, interval [, alias])`
 # Customisation
 Most behaviour in the package can be overridden or customised.
 
+## All_Time Grain
+If you're interested in returning the metric value across all time (or ignoring time bounds all together), you can include the `all_time` grain in the metric definition and then use that in the `calculate` or `develop` macro. This will return a single value for the metric (more if dimensions included) and the start/end date range for that metric calculation.
+
 ## Expression Metrics 
 Version `0.3.0` of this package, and beyond, offer support for `expression` metrics! More information around this type can be found in the[`metrics` page of dbt docs](https://docs.getdbt.com/docs/building-a-dbt-project/metrics)/.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
    * [Period to Date (<a href="/macros/secondary_calculations/secondary_calculation_period_to_date.sql">source</a>)](#period-to-date-source)
    * [Rolling (<a href="/macros/secondary_calculations/secondary_calculation_rolling.sql">source</a>)](#rolling-source)
 * [Customisation](#customisation)
+   * [All_Time Grain](#all_time-grain)
    * [Expression Metrics](#expression-metrics)
    * [Multiple Metrics](#multiple-metrics)
    * [Where Clauses](#where-clauses)
@@ -28,7 +29,7 @@
    * [Secondary calculation column aliases](#secondary-calculation-column-aliases)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: runner, at: Tue Aug 23 15:13:02 UTC 2022 -->
+<!-- Added by: runner, at: Tue Sep  6 16:03:30 UTC 2022 -->
 
 <!--te-->
 

--- a/integration_tests/models/metric_definitions/base_average_metric.yml
+++ b/integration_tests/models/metric_definitions/base_average_metric.yml
@@ -4,7 +4,7 @@ metrics:
     model: ref('fact_orders')
     label: Total Discount ($)
     timestamp: order_date
-    time_grains: [day, week, month]
+    time_grains: [day, week, month, all_time]
     type: average
     sql: discount_total
     dimensions:

--- a/integration_tests/models/metric_definitions/base_sum_metric.yml
+++ b/integration_tests/models/metric_definitions/base_sum_metric.yml
@@ -4,7 +4,18 @@ metrics:
     model: ref('fact_orders')
     label: Order Total ($)
     timestamp: order_date
-    time_grains: [day, week,month]
+    time_grains: [day, week, month, all_time]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+
+  - name: base_test_metric
+    model: ref('fact_orders')
+    label: Order Total ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
     type: sum
     sql: order_total
     dimensions:

--- a/integration_tests/models/metric_definitions/expression_metric.yml
+++ b/integration_tests/models/metric_definitions/expression_metric.yml
@@ -14,7 +14,7 @@ metrics:
   - name: ratio_metric
     label: Ratio ($)
     timestamp: order_date
-    time_grains: [day, week,month]
+    time_grains: [day, week, month, all_time]
     type: expression
     sql: "{{metric('base_sum_metric')}} / {{metric('base_average_metric')}}"
     dimensions:

--- a/integration_tests/models/metric_testing_models/base_average_metric__all_time.sql
+++ b/integration_tests/models/metric_testing_models/base_average_metric__all_time.sql
@@ -1,0 +1,6 @@
+select *
+from 
+{{ metrics.calculate(metric('base_average_metric'), 
+    grain='all_time',
+    dimensions=['had_discount']) 
+}}

--- a/integration_tests/models/metric_testing_models/base_sum_metric.sql
+++ b/integration_tests/models/metric_testing_models/base_sum_metric.sql
@@ -1,7 +1,7 @@
 select *
 from 
 {{ metrics.calculate(
-    metric('base_sum_metric'), 
-    grain='day', 
+    [metric('base_sum_metric'),metric('base_test_metric')], 
+    grain='all_time', 
     dimensions=['had_discount','is_weekend']) 
 }}

--- a/integration_tests/models/metric_testing_models/ratio_metric.sql
+++ b/integration_tests/models/metric_testing_models/ratio_metric.sql
@@ -1,6 +1,6 @@
 select *
 from 
 {{ metrics.calculate(metric('ratio_metric'), 
-    grain='month'
+    grain='all_time'
     )
 }}

--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -39,7 +39,7 @@ l{% macro calculate(metric_list, grain, dimensions=[], secondary_calculations=[]
         {%- do exceptions.raise_compiler_error("From v0.3.0 onwards, the where clause takes a single string, not a list of filters. Please fix to reflect this change") %}
     {%- endif -%}
 
-    {%- do metrics.validate_grain(grain=grain, metric_tree=metric_tree) -%}
+    {%- do metrics.validate_grain(grain=grain, metric_tree=metric_tree, secondary_calculations=secondary_calculations) -%}
 
     {%- do metrics.validate_expression_metrics(metric_tree=metric_tree) -%}
 

--- a/macros/sql_gen/build_metric_sql.sql
+++ b/macros/sql_gen/build_metric_sql.sql
@@ -15,24 +15,29 @@
     ) }}
     
     {#- Adding conditional logic to exclude the unique combinations of dimensions if there are no dimensions -#}
-    {%- if dimensions_provided == true -%}
-    
-        {{ metrics.gen_dimensions_cte(
-            metric_name=metric_dictionary.name, 
-            dimensions=dimensions
-        ) }}
-    
-    {%- endif -%}
+    {%- if grain != "all_time" -%}
 
-    {{ metrics.gen_spine_time_cte(
-        metric_name=metric_dictionary.name, 
-        grain=grain, 
-        dimensions=dimensions, 
-        secondary_calculations=secondary_calculations, 
-        relevant_periods=relevant_periods, 
-        calendar_dimensions=calendar_dimensions, 
-        dimensions_provided=dimensions_provided
-    )}}
+        {%- if dimensions_provided == true -%}
+        
+            {{ metrics.gen_dimensions_cte(
+                metric_name=metric_dictionary.name, 
+                dimensions=dimensions
+            ) }}
+        
+        {%- endif -%}
+
+
+        {{ metrics.gen_spine_time_cte(
+            metric_name=metric_dictionary.name, 
+            grain=grain, 
+            dimensions=dimensions, 
+            secondary_calculations=secondary_calculations, 
+            relevant_periods=relevant_periods, 
+            calendar_dimensions=calendar_dimensions, 
+            dimensions_provided=dimensions_provided
+        )}}
+
+    {%- endif -%}
 
     {{ metrics.gen_metric_cte(
         metric_name=metric_dictionary.name, 

--- a/macros/sql_gen/gen_aggregate_cte.sql
+++ b/macros/sql_gen/gen_aggregate_cte.sql
@@ -3,22 +3,25 @@
 {%- endmacro -%}
 
 {%- macro default__gen_aggregate_cte(metric_dictionary, grain, dimensions, secondary_calculations, start_date, end_date, calendar_tbl, relevant_periods, calendar_dimensions) %}
+
 , {{metric_dictionary.name}}__aggregate as (
     {# This is the most important CTE. Instead of joining all relevant information
     and THEN aggregating, we are instead aggregating from the beginning and then 
     joining downstream for performance. Additionally, we're using a subquery instead 
     of a CTE, which was significantly more performant during our testing. -#}
     select
-    
+
+        {%- if grain != 'all_time' %}
         date_{{grain}},
 
         {#- All of the other relevant periods that aren't currently selected as the grain
         are neccesary for downstream secondary calculations. We filter it on whether 
         there are secondary calculations to reduce the need for overhead -#}
-        {%- if secondary_calculations | length > 0 -%}
-            {%- for period in relevant_periods %}
+            {%- if secondary_calculations | length > 0 -%}
+                {%- for period in relevant_periods %}
         date_{{ period }},
-            {% endfor -%}
+                {% endfor -%}
+            {% endif -%}
         {% endif -%}
 
         {#- This is the consistent code you'll find that loops through the list of 
@@ -28,14 +31,20 @@
         {{ dim }},
         {%- endfor %}
 
-        {%- for calendar_dim in calendar_dimensions -%}
-            {{ calendar_dim }},
+        {%- for calendar_dim in calendar_dimensions %}
+        {{ calendar_dim }},
         {% endfor -%}
-        
+
         {#- This line performs the relevant aggregation by calling the 
         gen_primary_metric_aggregate macro. Take a look at that one if you're curious -#}
         {{ metrics.gen_primary_metric_aggregate(metric_dictionary.type, 'property_to_aggregate') }} as {{ metric_dictionary.name }},
+        
+        {%- if grain != 'all_time' %}
         {{ dbt_utils.bool_or('metric_date_day is not null') }} as has_data
+        {% else %}
+        min(metric_date_day) as metric_start_date,
+        max(metric_date_day) as metric_end_date
+        {% endif %}
 
     from ({{ metrics.gen_base_query(
                 metric_dictionary=metric_dictionary,
@@ -49,7 +58,7 @@
                 calendar_dimensions=calendar_dimensions) }}
     ) as base_query
 
-    group by {{ metrics.gen_group_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
+    {{ metrics.gen_group_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
 )
 
 {%- endmacro -%}

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -11,19 +11,25 @@
             {# This section looks at the sql aspect of the metric and ensures that 
             the value input into the macro is accurate -#}
             cast({{metric_dictionary.timestamp}} as date) as metric_date_day, -- timestamp field
+            
+            {%- if grain != 'all_time'%}
             calendar_table.date_{{ grain }} as date_{{grain}},
+            {% endif -%}
+
             {% if secondary_calculations | length > 0 -%}
                 {%- for period in relevant_periods %}
             calendar_table.date_{{ period }},
                 {% endfor -%}
             {%- endif -%}
-            -- ALL DIMENSIONS
+
             {%- for dim in dimensions %}
                 {{ dim }},
             {%- endfor %}
+
             {%- for calendar_dim in calendar_dimensions %}
                 {{ calendar_dim }},
             {%- endfor %}
+
             {%- if metric_dictionary.sql and metric_dictionary.sql | replace('*', '') | trim != '' %}
                 {{ metric_dictionary.sql }} as property_to_aggregate
             {%- elif metric_dictionary.dbt.type_numeric == 'count' -%}

--- a/macros/sql_gen/gen_group_by.sql
+++ b/macros/sql_gen/gen_group_by.sql
@@ -19,8 +19,18 @@ remove the grain from the list of relevant periods so it isnt double counted -#}
     {%- set period_length = relevant_periods | length -%}
     {%- set total_length = dimension_length + period_length + calendar_dimension_length -%}
 
-    {% for number in range(1,total_length+2) -%}
-        {{ number }} {%- if not loop.last -%}, {% endif -%}
-    {% endfor -%}
+    {% if grain == 'all_time' %}
+        {% if total_length > 0%}
+            group by
+            {% for number in range(1,total_length+1) -%}
+                {{ number }} {%- if not loop.last -%}, {% endif -%}
+            {% endfor -%}
+        {% endif %}
+    {% else %}
+        group by
+        {% for number in range(1,total_length+2) -%}
+            {{ number }} {%- if not loop.last -%}, {% endif -%}
+        {% endfor -%}
+    {% endif %}
 
 {% endmacro %}

--- a/macros/sql_gen/gen_joined_metrics_cte.sql
+++ b/macros/sql_gen/gen_joined_metrics_cte.sql
@@ -92,8 +92,8 @@
             {%- if loop.first %}
         {{ metric_name }}__final
             {%- else %}
-        left outer join {{metric_name}}__final
                 {%- if grain != 'all_time'%}
+        left outer join {{metric_name}}__final
                 using (
                     date_{{grain}}
                     {%- for calendar_dim in calendar_dimensions %}
@@ -103,8 +103,9 @@
                     , {{ dim }}
                     {%- endfor %}
                 )
-                {% else %}
+                {%- else -%}
                     {% if dimension_count != 0 %}
+        left outer join {{metric_name}}__final
                     using (
                         {%- for calendar_dim in calendar_dimensions %}
                             {%- if not loop.first -%},{%- endif -%} {{ calendar_dim }}
@@ -115,6 +116,8 @@
                         , {{ dim }}
                         {%- endfor -%}
                     )
+                    {%- elif dimension_count == 0 %}
+        cross join {{metric_name}}__final
                     {%- endif %}
                 {%- endif %}
             {%- endif -%}

--- a/macros/sql_gen/gen_spine_time_cte.sql
+++ b/macros/sql_gen/gen_spine_time_cte.sql
@@ -29,7 +29,7 @@
     {%- if dimensions_provided %}
     cross join {{metric_name}}__dims
     {%- endif %}
-    group by {{ metrics.gen_group_by(grain,dimensions,calendar_dimensions,relevant_periods) }}
+    {{ metrics.gen_group_by(grain,dimensions,calendar_dimensions,relevant_periods) }}
 
 )
 {%- endmacro -%}

--- a/macros/validation/validate_grain.sql
+++ b/macros/validation/validate_grain.sql
@@ -1,4 +1,4 @@
-{% macro validate_grain(grain, metric_tree) %}
+{% macro validate_grain(grain, metric_tree, secondary_calculations) %}
 
     {# We loop through the full set here to ensure that the provided grain works for all metrics
     returned or used, not just those listed #}
@@ -13,5 +13,9 @@
             {% endif %}
         {% endif %}
     {% endfor %}
+
+    {% if grain == 'all_time' and secondary_calculations | length > 0 %}
+        {%- do exceptions.raise_compiler_error("The selected grain - all_time - does not support secondary calculations.") %}
+    {% endif %}
 
 {% endmacro %}

--- a/tests/functional/invalid_configs/test_invalid_all_time_with_secondary_calculation.py
+++ b/tests/functional/invalid_configs/test_invalid_all_time_with_secondary_calculation.py
@@ -1,0 +1,88 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/base_sum_metric.sql
+base_sum_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('base_sum_metric'), 
+    grain='all_time',
+    secondary_calculations=[
+        metrics.period_over_period(comparison_strategy="difference", interval=1, alias = "1mth")
+    ]
+    )
+}}
+"""
+
+# models/base_sum_metric.yml
+base_sum_metric_yml = """
+version: 2 
+
+metrics:
+  - name: base_sum_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+
+class TestInvalidAllTimeWithSecondaryCalculations:
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "base_sum_metric.sql": base_sum_metric_sql,
+            "base_sum_metric.yml": base_sum_metric_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+        results = run_dbt(["seed"])
+
+        # Here we expect the run to fail because the incorrect
+        # time grain won't allow it to compile
+        results = run_dbt(["run"], expect_pass = False)

--- a/tests/functional/metric_options/all_time/test_all_time_nested_expression_metric.py
+++ b/tests/functional/metric_options/all_time/test_all_time_nested_expression_metric.py
@@ -1,0 +1,132 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/metric_on_expression_metric.sql
+metric_on_expression_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('metric_on_expression_metric'), 
+    grain='all_time'
+    )
+}}
+"""
+
+# models/base_sum_metric.yml
+base_sum_metric_yml = """
+version: 2 
+metrics:
+  - name: base_sum_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# models/expression_metric.yml
+metric_on_expression_metric_yml = """
+version: 2 
+models:
+  - name: metric_on_expression_metric
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('metric_on_expression_metric__expected')
+metrics:
+  - name: expression_metric
+    label: Expression ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
+    type: expression
+    sql: "{{metric('base_sum_metric')}} + 1"
+    dimensions:
+      - had_discount
+      - order_country
+
+  - name: metric_on_expression_metric
+    label: Expression ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
+    type: expression
+    sql: "{{metric('expression_metric')}} + 1"
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/metric_on_expression_metric__expected.csv
+metric_on_expression_metric__expected_csv = """
+metric_start_date,metric_end_date,base_sum_metric,metric_on_expression_metric,expression_metric
+2022-01-06,2022-02-15,14,16,15
+""".lstrip()
+
+class TestAllTimeMetricOnExpressionMetric:
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "metric_on_expression_metric__expected.csv": metric_on_expression_metric__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.yml": fact_orders_yml,
+            "base_sum_metric.yml": base_sum_metric_yml,
+            "metric_on_expression_metric.yml": metric_on_expression_metric_yml,
+            "fact_orders.sql": fact_orders_sql,
+            "metric_on_expression_metric.sql": metric_on_expression_metric_sql
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Right now, the metrics package will always return a date spined result set that shows the metric over a length of time. But what if the user just wants a single number? For that, we've added `all_time` as an acceptable input for all metric types. This produces a dataset that is not date spined but instead corresponds to the lifetime of value included in the macro call.

IE - if a user designates `start_date` and `end_date` and then uses `all_time` as the grain, it will return the value of the metric in that time period.

For cleanliness and ease of understanding, we've included `metric_start_date` and `metric_end_date` in the returned dataset.

<details>
<summary> Example output - no dimensions </summary>

|base_average_metric|metric_start_date|metric_end_date|
|-------------------|-----------------|---------------|
|0.9|2022-01-06|2022-02-15|

</details>

<details>
<summary> Example output - with dimensions </summary>

|had_discount|base_average_metric|metric_start_date|metric_end_date|
|-------------------|-------------------|-----------------|---------------|
|true|.66667|2022-01-06|2022-02-15|
|false|1|2022-01-08|2022-02-13|

</details>

### Important Changes
- Added `secondary_calculations` to `validate_grain`. This checks to make sure that there are no `secondary_calculations` provided if the grain is `all_time`, as those are not supported.
- Add a conditional check in `build_metric_sql` to not run `gen_dimensions_cte` or `gen_spine_time_cte` if the grain is `all_time`
- Add a conditional check in `gen_aggregate_cte` to not add any date fields (such as date_day) to the grouping if the grain is `all_time`
- Add a conditional check in `gen_aggregate_cte` to include `metric_start_date` and `metric_end_date` if the grain is `all_time`
- Changed `gen_group_by` to support the date field now being an optional input. 
- Altering all downstream `gen` macros to not include the date field.
- Changing the logic used to generate the `using` statement in `gen_joined_metrics_cte` now that there are conditions in which there would be no fields provided. For those ones, we switch from using a left outer join to a cross join.
- Casting the input in `gen_metric_cte` to `parent_metric_cte` to make it easier to reference fields

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [X] Postgres
    - [x] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
