### PR TITLE
Secondary Calcs - Lets Limit These Inputs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You may want to materialize the results as a fixed table for querying. This is n
 When [dbt server](https://blog.getdbt.com/licensing-dbt/) is released in late 2022, you will be able to access these macros interactively, without needing to build each variant as a single dbt model. For more information, check out the [keynote presentation from Coalesce 2021](https://www.getdbt.com/coalesce-2021/keynote-the-metrics-system/).
 
 # Secondary calculations
-Secondary calculations are window functions which act on the primary metric. You can use them to compare a metric's value to an earlier period and calculate year-to-date sums or rolling averages.
+Secondary calculations are window functions which act on the primary metric or metrics. You can use them to compare values to an earlier period and calculate year-to-date sums or rolling averages.
 
 Create secondary calculations using the convenience [constructor](https://en.wikipedia.org/wiki/Constructor_(object-oriented_programming)) macros. Alternatively, you can manually create a list of dictionary entries (not recommended).
 
@@ -157,29 +157,40 @@ Create secondary calculations using the convenience [constructor](https://en.wik
 Column aliases are [automatically generated](#secondary-calculation-column-aliases), but you can override them by setting `alias`. 
 
 ## Period over Period ([source](/macros/secondary_calculations/secondary_calculation_period_over_period.sql))
+The period over period secondary calculation performs a calculation against the metric(s) in question by either determining the difference or the ratio between two points of time. This other point in time is determined by the input variable which looks at the grain selected in the macro. 
 
-Constructor: `metrics.period_over_period(comparison_strategy, interval [, alias])`
+Constructor: `metrics.period_over_period(comparison_strategy, interval [, alias, metric_list])`
 
-- `comparison_strategy`: How to calculate the delta between the two periods. One of [`"ratio"`, `"difference"`]. Required
-- `interval`: The number of periods to look back. Required
-- `alias`: The column alias for the resulting calculation. Optional
+| Parameter                  | Example | Description | Required |
+| -------------------------- | ----------- | ----------- | -----------|
+| `comparison_strategy`      | `ratio` or `difference` | How to calculate the delta between the two periods | Yes |
+| `interval`                 | 1 | Integer - the number of time grains to look back | Yes |
+| `alias`                    | 'week_over_week' | The column alias for the resulting calculation | No |
+| `metric_list`              | 'base_sum_metric' | List of metrics that the secondary calculation should be applied to. Default is all metrics selected | No |
 
 ## Period to Date ([source](/macros/secondary_calculations/secondary_calculation_period_to_date.sql))
+The period to date secondary calculation performs an aggregation on a defined **period** of time that is equal to or coarser (higher, more aggregated) than the grain selected. Great example of this is when you want to display a month_to_date value alongside your weekly grained metric.
 
-Constructor: `metrics.period_to_date(aggregate, period [, alias])`
+Constructor: `metrics.period_to_date(aggregate, period [, alias, metric_list])`
 
-- `aggregate`: The aggregation to use in the window function. Options vary based on the primary aggregation and are enforced in [validate_aggregate_coherence()](/macros/secondary_calculations/validate_aggregate_coherence.sql). Required
-- `period`: The time grain to aggregate to. One of [`"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`]. Must be at equal or lesser granularity than the metric's grain (see [Time Grains](#time-grains) below). Required
-- `alias`: The column alias for the resulting calculation. Optional
+| Parameter                  | Example | Description | Required |
+| -------------------------- | ----------- | ----------- | -----------|
+| `aggregate`                | `max`, `average` | The aggregation to use in the window function. Options vary based on the primary aggregation and are enforced in [validate_aggregate_coherence()](/macros/secondary_calculations/validate_aggregate_coherence.sql). | Yes |
+| `period`                   | `"day"`, `"week"` | The time grain to aggregate to. One of [`"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`]. Must be at equal or coarser (higher, more aggregated) granularity than the metric's grain (see [Time Grains](#time-grains) below). In example grain of `month`, the acceptable periods would be `month`, `quarter`, or `year`. | Yes |
+| `alias`                    | 'month_to_date' | The column alias for the resulting calculation | No |
+| `metric_list`              | 'base_sum_metric' | List of metrics that the secondary calculation should be applied to. Default is all metrics selected | No |
 
 ## Rolling ([source](/macros/secondary_calculations/secondary_calculation_rolling.sql))
+The rolling secondary calculation performs an aggregation on a defined number of rows in metric dataset. For example, if the user selects the `week` grain and sets a rolling secondary calculation to `4` then the value returned will be a rolling 4 week calculation of whatever aggregation type was selected.
 
-Constructor: `metrics.rolling(aggregate, interval [, alias])`
+Constructor: `metrics.rolling(aggregate, interval [, alias, metric_list])`
 
-- `aggregate`: The aggregation to use in the window function. Options vary based on the primary aggregation and are enforced in [validate_aggregate_coherence()](/macros/secondary_calculations/validate_aggregate_coherence.sql). Required
-- `interval`: The number of periods to look back. Required
-- `alias`: The column alias for the resulting calculation. Optional
-
+| Parameter                  | Example | Description | Required |
+| -------------------------- | ----------- | ----------- | -----------|
+| `aggregate`                | `max`, `average` | The aggregation to use in the window function. Options vary based on the primary aggregation and are enforced in [validate_aggregate_coherence()](/macros/secondary_calculations/validate_aggregate_coherence.sql). | Yes |
+| `interval`                 | 1 | Integer - the number of time grains to look back | Yes |
+| `alias`                    | 'month_to_date' | The column alias for the resulting calculation | No |
+| `metric_list`              | 'base_sum_metric' | List of metrics that the secondary calculation should be applied to. Default is all metrics selected | No |
 
 # Customisation
 Most behaviour in the package can be overridden or customised.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
    * [Secondary calculation column aliases](#secondary-calculation-column-aliases)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: runner, at: Tue Aug 23 15:13:02 UTC 2022 -->
+<!-- Added by: runner, at: Wed Sep 21 02:26:03 UTC 2022 -->
 
 <!--te-->
 

--- a/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
@@ -5,8 +5,11 @@
       grain='day', 
       dimensions=['had_discount'], 
       secondary_calculations=[
-        {"calculation": "period_over_period", "interval": 1, "comparison_strategy": "difference", "alias": "pop_1mth"},
-        {"calculation": "period_over_period", "interval": 1, "comparison_strategy": "ratio"},
-      ] 
+        metrics.period_over_period(
+            comparison_strategy="difference"
+            ,interval=1
+            ,metric_list=['base_sum_metric']
+            )
+          ] 
       )
   }}

--- a/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
+++ b/integration_tests/models/metric_testing_models/multiple_metrics__period_over_period.sql
@@ -8,7 +8,7 @@
         metrics.period_over_period(
             comparison_strategy="difference"
             ,interval=1
-            ,metric_list=['base_sum_metric']
+            ,metric_list='base_sum_metric'
             )
           ] 
       )

--- a/macros/secondary_calculations/secondary_calculation_period_over_period.sql
+++ b/macros/secondary_calculations/secondary_calculation_period_over_period.sql
@@ -30,25 +30,3 @@
 {% macro default__metric_comparison_strategy_ratio(metric_name, calc_sql) %}
     cast(coalesce({{ metric_name }}, 0) as {{ type_float() }}) / nullif({{ calc_sql }}, 0) 
 {% endmacro %}
-
-{% macro period_over_period(comparison_strategy, interval, alias) %}
-
-    {% set missing_args = [] %}
-    {% if not comparison_strategy %}
-        {% set _ = missing_args.append("comparison_strategy") %}
-    {% endif %}
-    {% if not interval %} 
-        {% set _ = missing_args.append("interval") %}
-    {% endif %}
-    {% if missing_args | length > 0 %}
-        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
-    {% endif %}
-
-    {% do return ({
-        "calculation": "period_over_period",
-        "comparison_strategy": comparison_strategy,
-        "interval": interval,
-        "alias": alias
-        })
-    %}
-{% endmacro %}

--- a/macros/secondary_calculations/secondary_calculation_period_to_date.sql
+++ b/macros/secondary_calculations/secondary_calculation_period_to_date.sql
@@ -14,25 +14,3 @@
     {%- do return (calc_sql) %}
     
 {% endmacro %}
-
-{% macro period_to_date(aggregate, period, alias) %}
-
-    {% set missing_args = [] %}
-    {% if not aggregate %} 
-        {% set _ = missing_args.append("aggregate") %}
-    {% endif %}
-    {% if not period %}
-        {% set _ = missing_args.append("period") %}
-    {% endif %}
-    {% if missing_args | length > 0 %}
-        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_to_date') %}
-    {% endif %}
-
-    {% do return ({
-        "calculation": "period_to_date",
-        "aggregate": aggregate,
-        "period": period,
-        "alias": alias
-        })
-    %}
-{% endmacro %}

--- a/macros/secondary_calculations/secondary_calculation_rolling.sql
+++ b/macros/secondary_calculations/secondary_calculation_rolling.sql
@@ -13,25 +13,3 @@
     {% do return (calc_sql) %}
 
 {% endmacro %}
-
-{% macro rolling(aggregate, interval, alias) %}
-
-    {% set missing_args = [] %}
-    {% if not aggregate %} 
-        {% set _ = missing_args.append("aggregate") %}
-    {% endif %}
-    {% if not interval %}
-        {% set _ = missing_args.append("interval") %}
-    {% endif %}
-    {% if missing_args | length > 0 %}
-        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
-    {% endif %}
-
-    {% do return ({
-        "calculation": "rolling",
-        "aggregate": aggregate,
-        "interval": interval,
-        "alias": alias
-        })
-    %}
-{% endmacro %}

--- a/macros/secondary_calculations_configuration/period_over_period.sql
+++ b/macros/secondary_calculations_configuration/period_over_period.sql
@@ -1,0 +1,22 @@
+{% macro period_over_period(comparison_strategy, interval, alias, metric_list = []) %}
+
+    {% set missing_args = [] %}
+    {% if not comparison_strategy %}
+        {% set _ = missing_args.append("comparison_strategy") %}
+    {% endif %}
+    {% if not interval %} 
+        {% set _ = missing_args.append("interval") %}
+    {% endif %}
+    {% if missing_args | length > 0 %}
+        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
+    {% endif %}
+
+    {% do return ({
+        "calculation": "period_over_period",
+        "comparison_strategy": comparison_strategy,
+        "interval": interval,
+        "alias": alias,
+        "metric_list": metric_list
+        })
+    %}
+{% endmacro %}

--- a/macros/secondary_calculations_configuration/period_over_period.sql
+++ b/macros/secondary_calculations_configuration/period_over_period.sql
@@ -10,6 +10,9 @@
     {% if missing_args | length > 0 %}
         {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
     {% endif %}
+    {% if metric_list is string %}
+        {% set metric_list = [metric_list] %}
+    {% endif %}
 
     {% do return ({
         "calculation": "period_over_period",

--- a/macros/secondary_calculations_configuration/period_to_date.sql
+++ b/macros/secondary_calculations_configuration/period_to_date.sql
@@ -10,7 +10,10 @@
     {% if missing_args | length > 0 %}
         {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_to_date') %}
     {% endif %}
-
+    {% if metric_list is string %}
+        {% set metric_list = [metric_list] %}
+    {% endif %}
+    
     {% do return ({
         "calculation": "period_to_date",
         "aggregate": aggregate,

--- a/macros/secondary_calculations_configuration/period_to_date.sql
+++ b/macros/secondary_calculations_configuration/period_to_date.sql
@@ -1,0 +1,22 @@
+{% macro period_to_date(aggregate, period, alias, metric_list = []) %}
+
+    {% set missing_args = [] %}
+    {% if not aggregate %} 
+        {% set _ = missing_args.append("aggregate") %}
+    {% endif %}
+    {% if not period %}
+        {% set _ = missing_args.append("period") %}
+    {% endif %}
+    {% if missing_args | length > 0 %}
+        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_to_date') %}
+    {% endif %}
+
+    {% do return ({
+        "calculation": "period_to_date",
+        "aggregate": aggregate,
+        "period": period,
+        "alias": alias,
+        "metric_list": metric_list
+        })
+    %}
+{% endmacro %}

--- a/macros/secondary_calculations_configuration/rolling.sql
+++ b/macros/secondary_calculations_configuration/rolling.sql
@@ -1,0 +1,22 @@
+{% macro rolling(aggregate, interval, alias, metric_list=[]) %}
+
+    {% set missing_args = [] %}
+    {% if not aggregate %} 
+        {% set _ = missing_args.append("aggregate") %}
+    {% endif %}
+    {% if not interval %}
+        {% set _ = missing_args.append("interval") %}
+    {% endif %}
+    {% if missing_args | length > 0 %}
+        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
+    {% endif %}
+
+    {% do return ({
+        "calculation": "rolling",
+        "aggregate": aggregate,
+        "interval": interval,
+        "alias": alias,
+        "metric_list": metric_list
+        })
+    %}
+{% endmacro %}

--- a/macros/secondary_calculations_configuration/rolling.sql
+++ b/macros/secondary_calculations_configuration/rolling.sql
@@ -10,7 +10,10 @@
     {% if missing_args | length > 0 %}
         {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
     {% endif %}
-
+    {% if metric_list is string %}
+        {% set metric_list = [metric_list] %}
+    {% endif %}
+    
     {% do return ({
         "calculation": "rolling",
         "aggregate": aggregate,

--- a/macros/sql_gen/gen_secondary_calculations_cte.sql
+++ b/macros/sql_gen/gen_secondary_calculations_cte.sql
@@ -12,35 +12,28 @@ easier for not having to update the working secondary calc logic #}
 ,secondary_calculations as (
 
     select *
-        
-        {# Checking if base_set is a list - which you'd think would have its own test but no
-        Jinja doesn't have that built in so we have to hack it by checking if it is an 
-        iterable variable and NOT sring /mapping #}
-        {% if base_set is iterable and (base_set is not string and base_set is not mapping) %} 
 
-            {% for metric_name in base_set -%}
-
-                {% for calc_config in secondary_calculations -%}
-                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, true) }}
-
+        {% set is_multiple_metrics = base_set | length > 1 %}
+        {% for calc_config in secondary_calculations -%}
+            {% if calc_config.metric_list | length > 0 %}
+                {% for metric_name in calc_config.metric_list -%}
+                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, is_multiple_metrics) }}
+                {% endfor %}    
+            {% else %}
+                {% for metric_name in base_set -%}
+                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, is_multiple_metrics) }}
                 {% endfor %}
+            {% endif%}
+        
+        {% endfor %}
 
-            {% endfor %}
 
-        {% else %}
-
-            {% for calc_config in secondary_calculations -%}
-                , {{ metrics.perform_secondary_calculation(base_set, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(base_set,calc_config, grain, false) }}
-
-            {% endfor %}
-
-        {% endif %}
 
     from 
         {% if full_set|length > 1 %} 
             joined_metrics
         {% else %} 
-            {{base_set[0]}}__final
+            {{ base_set[0] }}__final
         {% endif %}
 )
 

--- a/macros/sql_gen/gen_secondary_calculations_cte.sql
+++ b/macros/sql_gen/gen_secondary_calculations_cte.sql
@@ -13,15 +13,15 @@ easier for not having to update the working secondary calc logic #}
 
     select *
 
-        {% set is_multiple_metrics = base_set | length > 1 %}
+        {# {% set is_multiple_metrics = base_set | length > 1 %} #}
         {% for calc_config in secondary_calculations -%}
             {% if calc_config.metric_list | length > 0 %}
                 {% for metric_name in calc_config.metric_list -%}
-                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, is_multiple_metrics) }}
+                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, true) }}
                 {% endfor %}    
             {% else %}
                 {% for metric_name in base_set -%}
-                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, is_multiple_metrics) }}
+                    , {{ metrics.perform_secondary_calculation(metric_name, grain, dimensions, calc_config) -}} as {{ metrics.generate_secondary_calculation_alias(metric_name,calc_config, grain, true) }}
                 {% endfor %}
             {% endif%}
         

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_secondary_calcs.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_secondary_calcs.py
@@ -1,0 +1,146 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/multiple_metrics.sql
+multiple_metrics_sql = """
+select *
+from 
+{{ metrics.calculate(
+    [metric('base_sum_metric'), metric('base_count_metric')],
+    grain='month',
+    secondary_calculations=[
+    metrics.period_over_period(
+        comparison_strategy="difference"
+        ,interval=1
+        ,metric_list=['base_sum_metric']
+        ),
+    metrics.period_to_date(
+        aggregate="sum"
+        ,period="year"
+        ,metric_list=['base_sum_metric','base_count_metric']
+        ),
+    metrics.rolling(
+        aggregate="max"
+        ,interval=4
+        ,metric_list='base_sum_metric'
+        )
+        ] 
+    )
+}}
+"""
+
+# models/multiple_metrics.yml
+multiple_metrics_yml = """
+version: 2 
+models:
+  - name: multiple_metrics
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('multiple_metrics__expected')
+metrics:
+  - name: base_count_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: count
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+
+  - name: base_sum_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    type: sum
+    sql: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/multiple_metrics__expected.csv
+multiple_metrics__expected_csv = """
+date_month,date_year,base_sum_metric,base_count_metric,base_sum_metric_difference_to_1_month_ago,base_sum_metric_sum_for_year,base_count_metric_sum_for_year,base_sum_metric_rolling_max_4_month
+2022-01-01,2022-01-01,8,7,8,8,7,8
+2022-02-01,2022-01-01,6,3,-2,14,10,8
+""".lstrip()
+
+class TestMultipleMetricsSecondaryCalcs:
+
+    # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "multiple_metrics__expected.csv": multiple_metrics__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "multiple_metrics.sql": multiple_metrics_sql,
+            "multiple_metrics.yml": multiple_metrics_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [X] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Based on some feedback from integration partners, we've added the following parameter to all secondary calculations:
- `metric_list`: this input takes a string name of a metric OR a list of string metric names. This limits the calculation to the metric in question

I've added tests to confirm that this behavior works as inspected and updated the README for this behavior.

A mimic of this PR will have to be applied to main instead of `0.3.latest` in order to have this behavior reflected in the 1.3 release.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
