### PR TITLE
Adding Prior Secondary Calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
       - "**.md"
     branches:
       - "main"
+      - "*.latest"
   pull_request:
     paths-ignore:
       - "**.md"
+
+# will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   postgres:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
    * [Period over Period (<a href="/macros/secondary_calculations/secondary_calculation_period_over_period.sql">source</a>)](#period-over-period-source)
    * [Period to Date (<a href="/macros/secondary_calculations/secondary_calculation_period_to_date.sql">source</a>)](#period-to-date-source)
    * [Rolling (<a href="/macros/secondary_calculations/secondary_calculation_rolling.sql">source</a>)](#rolling-source)
+   * [Prior (<a href="/macros/secondary_calculations/secondary_calculation_prior.sql">source</a>)](#prior-source)
 * [Customisation](#customisation)
    * [Metric Configs](#metric-configs)
       * [Accepted Metric Configurations](#accepted-metric-configurations)
@@ -35,7 +36,7 @@
    * [Secondary calculation column aliases](#secondary-calculation-column-aliases)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: runner, at: Mon Sep 26 19:12:12 UTC 2022 -->
+<!-- Added by: runner, at: Fri Sep 30 21:18:04 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ Constructor: `metrics.rolling(aggregate, interval [, alias, metric_list])`
 | `alias`                    | `month_to_date` | The column alias for the resulting calculation | No |
 | `metric_list`              | `base_sum_metric` | List of metrics that the secondary calculation should be applied to. Default is all metrics selected | No |
 
+## Prior ([source](/macros/secondary_calculations/secondary_calculation_prior.sql))
+
+The prior secondary calculation returns the value from a specified number of intervals prior to the row. 
+
+Constructor: `metrics.prior(interval [, alias, metric_list])`
+
+| Input                      | Example | Description | Required |
+| -------------------------- | ----------- | ----------- | -----------|
+| `interval`                 | 1 | Integer - the number of time grains to look back | Yes |
+| `alias`                    | `2_weeks_prior` | The column alias for the resulting calculation | No |
+| `metric_list`              | `base_sum_metric` | List of metrics that the secondary calculation should be applied to. Default is all metrics selected | No |
+
 
 # Customisation
 Most behaviour in the package can be overridden or customised.

--- a/integration_tests/models/metric_testing_models/base_sum_metric__prior.sql
+++ b/integration_tests/models/metric_testing_models/base_sum_metric__prior.sql
@@ -1,0 +1,9 @@
+select *
+from 
+{{ metrics.calculate(
+    metric('base_sum_metric'), 
+    grain='week', 
+    dimensions=['had_discount'],
+    secondary_calculations=[metrics.prior(interval=3)] 
+    ) 
+}}

--- a/jsonschema/secondary_calculations.json
+++ b/jsonschema/secondary_calculations.json
@@ -1,0 +1,113 @@
+{
+    "$defs": {
+      "PeriodToDate": {
+        "type": "object",
+        "required": ["function", "args"],
+        "additionalProperties": false,
+        "properties": {
+          "function": {
+            "type": "string",
+            "const": "period_to_date"
+          },
+          "args": {
+            "type": "object",
+            "required": ["aggregate", "period"],
+            "additionalProperties": false,
+            "properties": {
+              "alias": { "type": "string" },
+              "aggregate": {
+                "type": "string",
+                "enum": ["min", "max", "sum", "average"]
+              },
+              "period": {
+                "type": "string",
+                "enum": ["day", "week", "month", "quarter", "year"]
+              }
+            }
+          }
+        }
+      },
+      "PeriodOverPeriod": {
+        "type": "object",
+        "required": ["function", "args"],
+        "additionalProperties": false,
+        "properties": {
+          "function": {
+            "type": "string",
+            "const": "period_over_period"
+          },
+          "args": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": ["comparison_strategy", "interval"],
+            "properties": {
+              "alias": { "type": "string" },
+              "comparison_strategy": {
+                "type": "string",
+                "enum": ["ratio", "difference"]
+              },
+              "interval": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "Prior": {
+        "type": "object",
+        "required": ["function", "args"],
+        "additionalProperties": false,
+        "properties": {
+          "function": {
+            "type": "string",
+            "const": "prior"
+          },
+          "args": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": ["interval"],
+            "properties": {
+              "alias": { "type": "string" },
+              "interval": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        }
+      },
+      "Rolling": {
+        "type": "object",
+        "required": ["function", "args"],
+        "additionalProperties": false,
+        "properties": {
+          "function": {
+            "type": "string",
+            "const": "rolling"
+          },
+          "args": {
+            "type": "object",
+            "required": ["aggregate", "interval"],
+            "additionalProperties": false,
+            "properties": {
+              "alias": { "type": "string" },
+              "aggregate": {
+                "type": "string",
+                "enum": ["min", "max", "sum", "average"]
+              },
+              "interval": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        }
+      }
+    },
+  
+    "anyOf": [
+      { "$ref": "#/$defs/PeriodToDate" },
+      { "$ref": "#/$defs/PeriodOverPeriod" },
+      { "$ref": "#/$defs/Prior" },
+      { "$ref": "#/$defs/Rolling" }
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema"
+  }

--- a/macros/secondary_calculations/generate_secondary_calculation_alias.sql
+++ b/macros/secondary_calculations/generate_secondary_calculation_alias.sql
@@ -35,6 +35,13 @@
             {%- do return(calc_config.aggregate ~ "_for_" ~ calc_config.period) %}
         {% endif %}
         
+    {%- elif calc_type == 'prior' %}
+        {% if is_multiple_metrics %}
+            {%- do return(metric_name ~ "_" ~ calc_config.interval ~ "_" ~ grain ~ "s_prior") %}
+        {% else %}
+            {%- do return(calc_config.interval ~ "_" ~ grain ~ "s_prior") %}
+        {% endif %}
+
     {%- else %}
         {%- do exceptions.raise_compiler_error("Can't generate alias for unknown secondary calculation: " ~ calc_type ~ ". calc_config: " ~ calc_config) %}  
     {%- endif %}

--- a/macros/secondary_calculations/perform_secondary_calculation.sql
+++ b/macros/secondary_calculations/perform_secondary_calculation.sql
@@ -14,6 +14,8 @@
         {%- set calc_sql = adapter.dispatch('secondary_calculation_rolling', 'metrics')(metric_name, grain, dimensions, calc_config) -%}
     {%- elif calc_type == 'period_to_date' -%}
         {%- set calc_sql = adapter.dispatch('secondary_calculation_period_to_date', 'metrics')(metric_name, grain, dimensions, calc_config) -%}
+    {%- elif calc_type == 'prior' -%}
+        {%- set calc_sql = adapter.dispatch('secondary_calculation_prior', 'metrics')(metric_name, grain, dimensions, calc_config) -%}
     {%- else -%}
         {%- do exceptions.raise_compiler_error("Unknown secondary calculation: " ~ calc_type ~ ". calc_config: " ~ calc_config) -%}  
     {%- endif -%}

--- a/macros/secondary_calculations/secondary_calculation_prior.sql
+++ b/macros/secondary_calculations/secondary_calculation_prior.sql
@@ -1,0 +1,16 @@
+{%- macro default__secondary_calculation_prior(metric_name, grain, dimensions, calc_config, metric_config) -%}
+    
+    {%- set calc_sql %}
+            lag(
+                {{ metric_name }}, {{ calc_config.interval }}
+            ) over (
+                {% if dimensions -%}
+                    partition by {{ dimensions | join(", ") }} 
+                {% endif -%}
+                order by date_{{grain}}
+            )
+    {%- endset-%}
+    
+    {{ calc_sql }}
+
+{% endmacro %}

--- a/macros/secondary_calculations_configuration/prior.sql
+++ b/macros/secondary_calculations_configuration/prior.sql
@@ -1,0 +1,21 @@
+{% macro prior(interval, alias, metric_list = []) %}
+
+    {% set missing_args = [] %}
+    {% if not interval %} 
+        {% set _ = missing_args.append("interval") %}
+    {% endif %}
+    {% if missing_args | length > 0 %}
+        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
+    {% endif %}
+    {% if metric_list is string %}
+        {% set metric_list = [metric_list] %}
+    {% endif %}
+
+    {% do return ({
+        "calculation": "prior",
+        "interval": interval,
+        "alias": alias,
+        "metric_list": metric_list
+        })
+    %}
+{% endmacro %}

--- a/macros/sql_gen/gen_final_cte.sql
+++ b/macros/sql_gen/gen_final_cte.sql
@@ -47,3 +47,89 @@
 {%- endif %}
 
 {%- endmacro %}
+
+{% macro redshift__gen_final_cte(metric_tree, grain, dimensions, calendar_dimensions, relevant_periods, secondary_calculations, where) %}
+
+
+{%- if secondary_calculations | length > 0 -%}
+
+    , final as (
+
+        select
+            *
+        from secondary_calculations
+    )
+
+    select * from final 
+
+    {# metric where clauses #}
+    {%- if where %}
+    where {{ where }}
+    {%- endif %}
+
+{% else %}
+
+    {%- if metric_tree.full_set | length > 1 %}
+
+    select * from joined_metrics
+    {#- metric where clauses -#}
+        {%- if where %}
+    where {{ where }}
+        {%- endif -%}
+
+    {% else %}
+
+    select * from {{metric_tree.base_set[0]}}__final 
+        {%- if where %}
+    where {{ where }}
+        {%- endif -%}
+    
+    {%- endif %}
+
+
+{%- endif %}
+
+{%- endmacro %}
+
+{% macro postgres__gen_final_cte(metric_tree, grain, dimensions, calendar_dimensions, relevant_periods, secondary_calculations, where) %}
+
+
+{%- if secondary_calculations | length > 0 -%}
+
+    , final as (
+
+        select
+            *
+        from secondary_calculations
+    )
+
+    select * from final 
+
+    {# metric where clauses #}
+    {%- if where %}
+    where {{ where }}
+    {%- endif %}
+
+{% else %}
+
+    {%- if metric_tree.full_set | length > 1 %}
+
+    select * from joined_metrics
+    {#- metric where clauses -#}
+        {%- if where %}
+    where {{ where }}
+        {%- endif -%}
+
+    {% else %}
+
+    select * from {{metric_tree.base_set[0]}}__final 
+        {%- if where %}
+    where {{ where }}
+        {%- endif -%}
+    
+    {%- endif %}
+
+
+{%- endif %}
+
+{%- endmacro %}

--- a/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
+++ b/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
@@ -1,0 +1,131 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/prior_metric.sql
+prior_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('prior_metric'), 
+    grain='week',
+    secondary_calculations=[metrics.prior(interval=2)]
+    )
+}}
+"""
+
+# models/prior_metric.yml
+prior_metric_yml = """
+version: 2 
+models:
+  - name: prior_metric
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('prior_metric__expected')
+metrics:
+  - name: prior_metric
+    model: ref('fact_orders')
+    label: Count Distinct
+    timestamp: order_date
+    time_grains: [day, week, month]
+    calculation_method: count
+    expression: customer_id
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/prior_metric__expected.csv
+prior_metric__expected_csv = """
+date_week,prior_metric,prior_metric_2_weeks_prior
+2022-02-14,1,1
+2022-02-07,1,1
+2022-01-31,1,3
+2022-01-24,1,1
+2022-01-17,3,2
+2022-01-10,1,
+2022-01-03,2,
+""".lstrip()
+
+
+# seeds/prior_metric__expected.yml
+prior_metric__expected_yml = """
+version: 2
+seeds:
+  - name: prior_metric__expected
+""".lstrip()
+
+class TestPrior:
+
+    # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "prior_metric__expected.csv": prior_metric__expected_csv,
+            "prior_metric__expected.yml": prior_metric__expected_yml
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "prior_metric.sql": prior_metric_sql,
+            "prior_metric.yml": prior_metric_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+        
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]

--- a/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
+++ b/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
@@ -8,6 +8,8 @@ from tests.functional.fixtures import (
     fact_orders_source_csv,
     fact_orders_sql,
     fact_orders_yml,
+    custom_calendar_sql
+
 )
 
 # models/prior_metric.sql
@@ -72,7 +74,11 @@ class TestPrior:
         def project_config_update(self):
             return {
             "name": "example",
-            "models": {"+materialized": "table"}
+            "models": {"+materialized": "table"},
+            "vars":{
+                "dbt_metrics_calendar_model": "custom_calendar",
+                "custom_calendar_dimension_list": ["is_weekend"]
+            }
             }
     else: 
         @pytest.fixture(scope="class")
@@ -106,6 +112,7 @@ class TestPrior:
         return {
             "fact_orders.sql": fact_orders_sql,
             "fact_orders.yml": fact_orders_yml,
+            "custom_calendar.sql": custom_calendar_sql,
             "prior_metric.sql": prior_metric_sql,
             "prior_metric.yml": prior_metric_yml
         }
@@ -120,7 +127,7 @@ class TestPrior:
 
         # initial run
         results = run_dbt(["run"])
-        assert len(results) == 3
+        assert len(results) == 4
         
         # test tests
         results = run_dbt(["test"]) # expect passing test


### PR DESCRIPTION
## What is this PR?
This is a:
- [X] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Based on #38 , this PR adds the `prior` secondary calculation in the new format. **This PR exists only to show the potential of what this would look like - it still has not been determined whether this should be included in the package**. 

We still need to determine whether this is worth the inclusion in the package or if we should offer this as example code for how people can override the package macros to provide their own secondary calculations.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
