### PR TITLE
Fixing the required dbt version for the 0.3 series

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,7 +19,7 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-require-dbt-version: [">=1.2.0-a1", "<2.0.0"]
+require-dbt-version: [">=1.2.0-a1", "<1.3.0"]
 
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`


### PR DESCRIPTION
## What is this PR?
This is a:
- [X] a breaking change

## Description & motivation
This PR will ensure that users of the most up to date 0.3 series of the package won't be able to run it with dbt 1.3.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
