### PR TITLE
Updating required dbt version to just 1.3

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,7 +19,7 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-require-dbt-version: [">=1.3.0-b1", "<2.0.0"]
+require-dbt-version: [">=1.3.0-b1", "<1.4.0"]
 
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,16 +2,23 @@ pytest
 pytest-dotenv
 
 # Bleeding edge
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-tests-adapter&subdirectory=tests/adapter
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-postgres&subdirectory=plugins/postgres
-git+https://github.com/dbt-labs/dbt-redshift.git
-git+https://github.com/dbt-labs/dbt-snowflake.git
-git+https://github.com/dbt-labs/dbt-bigquery.git
+# git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-tests-adapter&subdirectory=tests/adapter
+# git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-core&subdirectory=core
+# git+https://github.com/dbt-labs/dbt-core.git@main#egg=dbt-postgres&subdirectory=plugins/postgres
+# git+https://github.com/dbt-labs/dbt-redshift.git
+# git+https://github.com/dbt-labs/dbt-snowflake.git
+# git+https://github.com/dbt-labs/dbt-bigquery.git
 
 # Most recent release candidates
-# dbt-tests-adapter==1.2.0
-# dbt-core==1.2.0
-# dbt-redshift==1.2.0
-# dbt-snowflake==1.2.0
-# dbt-bigquery==1.2.0
+dbt-tests-adapter==1.3.0rc2
+dbt-core==1.3.0rc2
+dbt-redshift==1.3.0rc2
+dbt-snowflake==1.3.0rc2
+dbt-bigquery==1.3.0rc2
+
+# Most recent stable release
+# dbt-tests-adapter==1.3.0
+# dbt-core==1.3.0
+# dbt-redshift==1.3.0
+# dbt-snowflake==1.3.0
+# dbt-bigquery==1.3.0


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [X] a breaking change

## Description & motivation
This PR limits the required dbt version to the 1.3 range

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
