### PR TITLE
Fixing Redshift Order By Bug

### DIFF
--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -96,4 +96,6 @@
         relevant_periods=relevant_periods
     ) %}
     ({{ sql }}) metric_subq
+    {{- metrics.gen_order_by(grain, dimensions, calendar_dimensions, relevant_periods) -}}
+
 {%- endmacro %}

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -149,6 +149,7 @@ this is only a single metric and not an expression metric #}
         where=where) 
         }}
 
+
 {%- endif -%}
 
 {% endmacro %}

--- a/macros/sql_gen/gen_final_cte.sql
+++ b/macros/sql_gen/gen_final_cte.sql
@@ -20,7 +20,6 @@
     {%- if where %}
     where {{ where }}
     {%- endif %}
-    {{ metrics.gen_order_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
 
 {% else %}
 
@@ -31,7 +30,6 @@
         {%- if where %}
     where {{ where }}
         {%- endif -%}
-    {{ metrics.gen_order_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
 
     {% else %}
 
@@ -39,7 +37,6 @@
         {%- if where %}
     where {{ where }}
         {%- endif -%}
-    {{ metrics.gen_order_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
     
     {%- endif %}
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Fixes #130 caused by `order_by` statement in `gen_final_cte`. All this PR does is move the order by to the overarching sql statement instead of the final cte

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
