### PR TITLE
Fixing Bug Around Left Outer Join Vs Full Outer Join

### DIFF
--- a/macros/sql_gen/gen_joined_metrics_cte.sql
+++ b/macros/sql_gen/gen_joined_metrics_cte.sql
@@ -93,7 +93,7 @@
         {{ metric_name }}__final
             {%- else %}
                 {%- if grain != 'all_time'%}
-        left outer join {{metric_name}}__final
+        full outer join {{metric_name}}__final
                 using (
                     date_{{grain}}
                     {%- for calendar_dim in calendar_dimensions %}
@@ -105,7 +105,7 @@
                 )
                 {%- else -%}
                     {% if dimension_count != 0 %}
-        left outer join {{metric_name}}__final
+        full outer join {{metric_name}}__final
                     using (
                         {%- for calendar_dim in calendar_dimensions %}
                             {%- if not loop.first -%},{%- endif -%} {{ calendar_dim }}

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -149,3 +149,37 @@ packages_yml = """
   - package: calogica/dbt_expectations
     version: [">=0.5.0", "<0.6.0"]
 """
+
+# seeds/events.csv
+events_source_csv = """
+id,country,timestamp_field
+1,FR,2022-01-01
+2,UK,2022-02-01
+""".lstrip()
+
+# models/event.sql
+event_sql = """
+with source as (
+    select * from {{ ref('events_source') }}
+)
+,
+final as (
+    select *
+    from source 
+)
+select * from final
+"""
+
+# models/event.yml
+event_yml = """
+version: 2 
+models: 
+  - name: event
+    columns:
+      - name: id
+        description: TBD
+      - name: country
+        description: TBD
+      - name: timestamp_field
+        description: TBD
+"""

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_outer_join.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_outer_join.py
@@ -1,0 +1,137 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    events_source_csv,
+    event_sql,
+    event_yml,
+)
+
+# models/multiple_metrics.sql
+multiple_metrics_sql = """
+select *
+from {{
+  metrics.calculate(
+    [
+      metric('count_fr_events'),
+      metric('count_uk_events'),
+    ],
+    grain='month',
+  )
+}}
+"""
+
+# models/multiple_metrics.yml
+multiple_metrics_yml = """
+version: 2
+models:
+  - name: multiple_metrics
+    tests: 
+      - dbt_utils.equality:
+          compare_model: ref('multiple_metrics__expected')
+
+metrics:
+  - name: count_fr_events
+    label: Count number of events in France
+    model: ref('event')
+    type: count
+    sql: id
+    timestamp: timestamp_field
+    time_grains: [month]
+
+    filters:
+      - field: country
+        operator: '='
+        value: "'FR'"
+
+  - name: count_uk_events
+    label: Count number of events in UK
+    model: ref('event')
+    type: count
+    sql: id
+    timestamp: timestamp_field
+    time_grains: [month]
+
+    filters:
+      - field: country
+        operator: '='
+        value: "'UK'"
+"""
+
+# seeds/multiple_metrics__expected.csv
+multiple_metrics__expected_csv = """
+date_month,count_fr_events,count_uk_events
+2022-01-01,1,
+2022-02-01,,1
+""".lstrip()
+
+class TestMultipleMetrics:
+
+    # configuration in dbt_project.yml
+    # setting bigquery as table to get around query complexity 
+    # resource constraints with compunding views
+    if os.getenv('dbt_target') == 'bigquery':
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "table"}
+            }
+    else: 
+        @pytest.fixture(scope="class")
+        def project_config_update(self):
+            return {
+            "name": "example",
+            "models": {"+materialized": "view"}
+            }  
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "events_source.csv": events_source_csv,
+            "multiple_metrics__expected.csv": multiple_metrics__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "event.sql": event_sql,
+            "event.yml": event_yml,
+            "multiple_metrics.sql": multiple_metrics_sql,
+            "multiple_metrics.yml": multiple_metrics_yml
+        }
+
+    def test_build_completion(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Related to bug found in issue #132. It changes the `left outer join` in the `gen_joined_metrics_cte` to `full outer join` so that rows that are present in one metric aren't excluded by the join clause. Additionally it adds a test to ensure this behavior is consistent
 
## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have added tests & descriptions to my models (and macros if applicable)

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
