### PR TITLE
Removing dbt_utils date trunc functionality

### DIFF
--- a/integration_tests/models/custom_calendar.sql
+++ b/integration_tests/models/custom_calendar.sql
@@ -14,13 +14,13 @@ final as (
         cast(date_day as date) as date_day,
         {% if target.type == 'bigquery' %}
             --BQ starts its weeks on Sunday. I don't actually care which day it runs on for auto testing purposes, just want it to be consistent with the other seeds
-            cast({{ dbt_utils.date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
         {% else %}
-            cast({{ dbt_utils.date_trunc('week', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week', 'date_day') }} as date) as date_week,
         {% endif %}
-        cast({{ dbt_utils.date_trunc('month', 'date_day') }} as date) as date_month,
-        cast({{ dbt_utils.date_trunc('quarter', 'date_day') }} as date) as date_quarter,
-        cast({{ dbt_utils.date_trunc('year', 'date_day') }} as date) as date_year,
+        cast({{ date_trunc('month', 'date_day') }} as date) as date_month,
+        cast({{ date_trunc('quarter', 'date_day') }} as date) as date_quarter,
+        cast({{ date_trunc('year', 'date_day') }} as date) as date_year,
         true as is_weekend
     from days
 )

--- a/models/dbt_metrics_default_calendar.sql
+++ b/models/dbt_metrics_default_calendar.sql
@@ -12,10 +12,10 @@ with days as (
 final as (
     select 
         cast(date_day as date) as date_day,
-        cast({{ dbt_utils.date_trunc('week', 'date_day') }} as date) as date_week,
-        cast({{ dbt_utils.date_trunc('month', 'date_day') }} as date) as date_month,
-        cast({{ dbt_utils.date_trunc('quarter', 'date_day') }} as date) as date_quarter,
-        cast({{ dbt_utils.date_trunc('year', 'date_day') }} as date) as date_year
+        cast({{ date_trunc('week', 'date_day') }} as date) as date_week,
+        cast({{ date_trunc('month', 'date_day') }} as date) as date_month,
+        cast({{ date_trunc('quarter', 'date_day') }} as date) as date_quarter,
+        cast({{ date_trunc('year', 'date_day') }} as date) as date_year
     from days
 )
 

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -58,13 +58,13 @@ final as (
         cast(date_day as date) as date_day,
         {% if target.type == 'bigquery' %}
             --BQ starts its weeks on Sunday. I don't actually care which day it runs on for auto testing purposes, just want it to be consistent with the other seeds
-            cast({{ dbt_utils.date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
         {% else %}
-            cast({{ dbt_utils.date_trunc('week', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week', 'date_day') }} as date) as date_week,
         {% endif %}
-        cast({{ dbt_utils.date_trunc('month', 'date_day') }} as date) as date_month,
-        cast({{ dbt_utils.date_trunc('quarter', 'date_day') }} as date) as date_quarter,
-        cast({{ dbt_utils.date_trunc('year', 'date_day') }} as date) as date_year,
+        cast({{ date_trunc('month', 'date_day') }} as date) as date_month,
+        cast({{ date_trunc('quarter', 'date_day') }} as date) as date_quarter,
+        cast({{ date_trunc('year', 'date_day') }} as date) as date_year,
         true as is_weekend
     from days
 )

--- a/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
+++ b/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
@@ -26,13 +26,13 @@ final as (
         cast(date_day as date) as date_day,
         {% if target.type == 'bigquery' %}
             --BQ starts its weeks on Sunday. I don't actually care which day it runs on for auto testing purposes, just want it to be consistent with the other seeds
-            cast({{ dbt_utils.date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week(MONDAY)', 'date_day') }} as date) as date_week,
         {% else %}
-            cast({{ dbt_utils.date_trunc('week', 'date_day') }} as date) as date_week,
+            cast({{ date_trunc('week', 'date_day') }} as date) as date_week,
         {% endif %}
-        cast({{ dbt_utils.date_trunc('month', 'date_day') }} as date) as date_month,
-        cast({{ dbt_utils.date_trunc('quarter', 'date_day') }} as date) as date_quarter,
-        cast({{ dbt_utils.date_trunc('year', 'date_day') }} as date) as date_year,
+        cast({{ date_trunc('month', 'date_day') }} as date) as date_month,
+        cast({{ date_trunc('quarter', 'date_day') }} as date) as date_quarter,
+        cast({{ date_trunc('year', 'date_day') }} as date) as date_year,
         true as is_weekend
     from days
 )


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
dbt_utils version 0.9.0 moved the date_trunc functionality into dbt-core. This PR makes that update to the date trunc functionality which was the only deprecated function still being used.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
