### PR TITLE
Fixing Rolling Secondary Calc Typo

### DIFF
--- a/.changes/unreleased/Docs-20221011-094243.yaml
+++ b/.changes/unreleased/Docs-20221011-094243.yaml
@@ -1,0 +1,7 @@
+kind: Docs
+body: Fixing typo in rolling secondary calc
+time: 2022-10-11T09:42:43.49833-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "140"
+  PR: "141"

--- a/macros/secondary_calculations_configuration/rolling.sql
+++ b/macros/secondary_calculations_configuration/rolling.sql
@@ -8,7 +8,7 @@
         {% set _ = missing_args.append("interval") %}
     {% endif %}
     {% if missing_args | length > 0 %}
-        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to period_over_period') %}
+        {% do exceptions.raise_compiler_error( missing_args | join(", ") ~ ' not provided to rolling') %}
     {% endif %}
     {% if metric_list is string %}
         {% set metric_list = [metric_list] %}


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] bug fix with no breaking changes

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
A member of the community in issue #140 noticed that the error message for rolling was incorrect. This has been fixed in this PR

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
