### PR TITLE
Removing `bool_or` from dbt_utils reference

### DIFF
--- a/.changes/unreleased/Under the Hood-20221012-101830.yaml
+++ b/.changes/unreleased/Under the Hood-20221012-101830.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Removing bool or
+time: 2022-10-12T10:18:30.482027-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "142"
+  PR: "142"

--- a/macros/sql_gen/gen_aggregate_cte.sql
+++ b/macros/sql_gen/gen_aggregate_cte.sql
@@ -40,7 +40,7 @@
         {{ metrics.gen_primary_metric_aggregate(metric_dictionary.calculation_method, 'property_to_aggregate') }} as {{ metric_dictionary.name }},
 
         {%- if grain != 'all_time' %}
-        {{ dbt_utils.bool_or('metric_date_day is not null') }} as has_data
+        {{ bool_or('metric_date_day is not null') }} as has_data
         {% else %}
         min(metric_date_day) as metric_start_date,
         max(metric_date_day) as metric_end_date


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] bug fix with no breaking changes

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Bool Or has been moved to dbt core and thus we need to remove the reference.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
