### PR TITLE
Removing dbt utils dependency

### DIFF
--- a/.changes/unreleased/Under the Hood-20221012-114117.yaml
+++ b/.changes/unreleased/Under the Hood-20221012-114117.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Removing dbt_utils
+time: 2022-10-12T11:41:17.757328-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "143"
+  PR: "143"

--- a/integration_tests/models/custom_calendar.sql
+++ b/integration_tests/models/custom_calendar.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='table') }}
 
 with days as (
-    {{ dbt_utils.date_spine(
+    {{ metrics.metric_date_spine(
     datepart="day",
     start_date="cast('2010-01-01' as date)",
     end_date="cast('2030-01-01' as date)"

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,4 +1,4 @@
 packages:
   - local: ../
   - package: calogica/dbt_expectations
-    version: [">=0.5.0", "<0.6.0"]
+    version: [">=0.6.0", "<0.7.0"]

--- a/macros/misc/metrics__date_spine.sql
+++ b/macros/misc/metrics__date_spine.sql
@@ -1,0 +1,128 @@
+{% macro metric_get_intervals_between(start_date, end_date, datepart) -%}
+    {{ return(adapter.dispatch('metric_get_intervals_between', 'metrics')(start_date, end_date, datepart)) }}
+{%- endmacro %}
+
+{% macro default__metric_get_intervals_between(start_date, end_date, datepart) -%}
+    {%- call statement('metric_get_intervals_between', fetch_result=True) %}
+
+        select {{ datediff(start_date, end_date, datepart) }}
+
+    {%- endcall -%}
+
+    {%- set value_list = load_result('metric_get_intervals_between') -%}
+
+    {%- if value_list and value_list['data'] -%}
+        {%- set values = value_list['data'] | map(attribute=0) | list %}
+        {{ return(values[0]) }}
+    {%- else -%}
+        {{ return(1) }}
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{% macro metric_date_spine(datepart, start_date, end_date) %}
+    {{ return(adapter.dispatch('metric_date_spine', 'metrics')(datepart, start_date, end_date)) }}
+{%- endmacro %}
+
+{% macro default__metric_date_spine(datepart, start_date, end_date) %}
+
+
+{# call as follows:
+
+metric_date_spine(
+    "day",
+    "to_date('01/01/2016', 'mm/dd/yyyy')",
+    "dateadd(week, 1, current_date)"
+) #}
+
+
+with rawdata as (
+
+    {{metrics.metric_generate_series(
+        metrics.metric_get_intervals_between(start_date, end_date, datepart)
+    )}}
+
+),
+
+all_periods as (
+
+    select (
+        {{
+            dateadd(
+                datepart,
+                "row_number() over (order by 1) - 1",
+                start_date
+            )
+        }}
+    ) as date_{{datepart}}
+    from rawdata
+
+),
+
+filtered as (
+
+    select *
+    from all_periods
+    where date_{{datepart}} <= {{ end_date }}
+
+)
+
+select * from filtered
+
+{% endmacro %}
+
+
+{% macro metric_get_powers_of_two(upper_bound) %}
+    {{ return(adapter.dispatch('metric_get_powers_of_two', 'metrics')(upper_bound)) }}
+{% endmacro %}
+
+{% macro default__metric_get_powers_of_two(upper_bound) %}
+
+    {% if upper_bound <= 0 %}
+    {{ exceptions.raise_compiler_error("upper bound must be positive") }}
+    {% endif %}
+
+    {% for _ in range(1, 100) %}
+       {% if upper_bound <= 2 ** loop.index %}{{ return(loop.index) }}{% endif %}
+    {% endfor %}
+
+{% endmacro %}
+
+
+{% macro metric_generate_series(upper_bound) %}
+    {{ return(adapter.dispatch('metric_generate_series', 'metrics')(upper_bound)) }}
+{% endmacro %}
+
+{% macro default__metric_generate_series(upper_bound) %}
+
+    {% set n = metrics.metric_get_powers_of_two(upper_bound) %}
+
+    with p as (
+        select 0 as generated_number union all select 1
+    ), unioned as (
+
+    select
+
+    {% for i in range(n) %}
+    p{{i}}.generated_number * power(2, {{i}})
+    {% if not loop.last %} + {% endif %}
+    {% endfor %}
+    + 1
+    as generated_number
+
+    from
+
+    {% for i in range(n) %}
+    p as p{{i}}
+    {% if not loop.last %} cross join {% endif %}
+    {% endfor %}
+
+    )
+
+    select *
+    from unioned
+    where generated_number <= {{upper_bound}}
+    order by generated_number
+
+{% endmacro %}

--- a/macros/misc/metrics__equality.sql
+++ b/macros/misc/metrics__equality.sql
@@ -1,0 +1,99 @@
+{% test metric_equality(model, compare_model, compare_columns=None) %}
+  {{ return(adapter.dispatch('test_metric_equality', 'metrics')(model, compare_model, compare_columns)) }}
+{% endtest %}
+
+{% macro default__test_metric_equality(model, compare_model, compare_columns=None) %}
+
+{% set set_diff %}
+    count(*) + coalesce(abs(
+        sum(case when which_diff = 'a_minus_b' then 1 else 0 end) -
+        sum(case when which_diff = 'b_minus_a' then 1 else 0 end)
+    ), 0)
+{% endset %}
+
+{#-- Needs to be set at parse time, before we return '' below --#}
+{{ config(fail_calc = set_diff) }}
+
+{#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+{%- if not execute -%}
+    {{ return('') }}
+{% endif %}
+
+-- setup
+{%- do metrics._metric_is_relation(model, 'test_metric_equality') -%}
+
+{#-
+If the compare_cols arg is provided, we can run this test without querying the
+information schema — this allows the model to be an ephemeral model
+-#}
+
+{%- if not compare_columns -%}
+    {%- do metrics._metric_is_ephemeral(model, 'test_metric_equality') -%}
+    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted') -%}
+{%- endif -%}
+
+{% set compare_cols_csv = compare_columns | join(', ') %}
+
+with a as (
+
+    select * from {{ model }}
+
+),
+
+b as (
+
+    select * from {{ compare_model }}
+
+),
+
+a_minus_b as (
+
+    select {{compare_cols_csv}} from a
+    {{ except() }}
+    select {{compare_cols_csv}} from b
+
+),
+
+b_minus_a as (
+
+    select {{compare_cols_csv}} from b
+    {{ except() }}
+    select {{compare_cols_csv}} from a
+
+),
+
+unioned as (
+
+    select 'a_minus_b' as which_diff, a_minus_b.* from a_minus_b
+    union all
+    select 'b_minus_a' as which_diff, b_minus_a.* from b_minus_a
+
+)
+
+select * from unioned
+
+{% endmacro %}
+
+
+{% macro _metric_is_relation(obj, macro) %}
+    {%- if not (obj is mapping and obj.get('metadata', {}).get('type', '').endswith('Relation')) -%}
+        {%- do exceptions.raise_compiler_error("Macro " ~ macro ~ " expected a Relation but received the value: " ~ obj) -%}
+    {%- endif -%}
+{% endmacro %}
+
+{% macro _metric_is_ephemeral(obj, macro) %}
+    {%- if obj.is_cte -%}
+        {% set ephemeral_prefix = api.Relation.add_ephemeral_prefix('') %}
+        {% if obj.name.startswith(ephemeral_prefix) %}
+            {% set model_name = obj.name[(ephemeral_prefix|length):] %}
+        {% else %}
+            {% set model_name = obj.name %}
+        {%- endif -%}
+        {% set error_message %}
+The `{{ macro }}` macro cannot be used with ephemeral models, as it relies on the information schema.
+
+`{{ model_name }}` is an ephemeral model. Consider making it a view or table instead.
+        {% endset %}
+        {%- do exceptions.raise_compiler_error(error_message) -%}
+    {%- endif -%}
+{% endmacro %}

--- a/models/dbt_metrics_default_calendar.sql
+++ b/models/dbt_metrics_default_calendar.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='table') }}
 
 with days as (
-    {{ dbt_utils.date_spine(
+    {{ metrics.metric_date_spine(
     datepart="day",
     start_date="cast('1990-01-01' as date)",
     end_date="cast('2030-01-01' as date)"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - package: dbt-labs/dbt_utils
-    version: [">=0.9.0", "<1.0.0"]

--- a/tests/functional/base_metric_types/test_base_average_metric.py
+++ b/tests/functional/base_metric_types/test_base_average_metric.py
@@ -8,6 +8,7 @@ from tests.functional.fixtures import (
     fact_orders_source_csv,
     fact_orders_sql,
     fact_orders_yml,
+    packages_yml
 )
 
 # models/base_average_metric.sql
@@ -26,7 +27,7 @@ version: 2
 models:
   - name: base_average_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_average_metric__expected')
 metrics:
   - name: base_average_metric

--- a/tests/functional/base_metric_types/test_base_count_distinct_metric.py
+++ b/tests/functional/base_metric_types/test_base_count_distinct_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: base_count_distinct_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_count_distinct_metric__expected')
 
 metrics:

--- a/tests/functional/base_metric_types/test_base_count_metric.py
+++ b/tests/functional/base_metric_types/test_base_count_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: base_count_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_count_metric__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/base_metric_types/test_base_max_metric.py
+++ b/tests/functional/base_metric_types/test_base_max_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: base_max_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_max_metric__expected')
 metrics:
   - name: base_max_metric

--- a/tests/functional/base_metric_types/test_base_min_metric.py
+++ b/tests/functional/base_metric_types/test_base_min_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: base_min_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_min_metric__expected')
 metrics:
   - name: base_min_metric

--- a/tests/functional/base_metric_types/test_base_sum_metric.py
+++ b/tests/functional/base_metric_types/test_base_sum_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_sum_metric__expected')
 metrics:
   - name: base_sum_metric

--- a/tests/functional/derived_metric_types/test_derived_metric.py
+++ b/tests/functional/derived_metric_types/test_derived_metric.py
@@ -42,7 +42,7 @@ version: 2
 models:
   - name: derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('derived_metric__expected')
 metrics:
   - name: derived_metric

--- a/tests/functional/derived_metric_types/test_divide_by_zero_derived_metric.py
+++ b/tests/functional/derived_metric_types/test_divide_by_zero_derived_metric.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: divide_by_zero_expression_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('divide_by_zero_expression_metric__expected')
 metrics:
   - name: base_sum_metric

--- a/tests/functional/derived_metric_types/test_metric_on_derived_metric.py
+++ b/tests/functional/derived_metric_types/test_metric_on_derived_metric.py
@@ -42,7 +42,7 @@ version: 2
 models:
   - name: metric_on_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('metric_on_derived_metric__expected')
 metrics:
   - name: derived_metric

--- a/tests/functional/derived_metric_types/test_ratio_metric.py
+++ b/tests/functional/derived_metric_types/test_ratio_metric.py
@@ -58,7 +58,7 @@ version: 2
 models:
   - name: ratio_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('ratio_metric__expected')
 metrics:
   - name: ratio_metric

--- a/tests/functional/develop/test_develop_matches_calculate.py
+++ b/tests/functional/develop/test_develop_matches_calculate.py
@@ -70,7 +70,7 @@ version: 2
 models:
   - name: testing_metric_develop
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('testing_metric_calculate')
 
 """

--- a/tests/functional/develop/test_develop_metric.py
+++ b/tests/functional/develop/test_develop_metric.py
@@ -45,7 +45,7 @@ version: 2
 models:
   - name: develop_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('develop_metric__expected')
 
 """
@@ -209,7 +209,7 @@ version: 2
 models:
   - name: develop_multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('develop_multiple_metrics__expected')
 
 """

--- a/tests/functional/develop/test_develop_metric_dimensions.py
+++ b/tests/functional/develop/test_develop_metric_dimensions.py
@@ -44,7 +44,7 @@ version: 2
 models:
   - name: develop_metric_dimension
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('develop_metric_dimension__expected')
 
 """

--- a/tests/functional/develop/test_develop_window_functionality.py
+++ b/tests/functional/develop/test_develop_window_functionality.py
@@ -44,7 +44,7 @@ version: 2
 models:
   - name: develop_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('develop_metric__expected')
 """
 

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -46,7 +46,7 @@ purchased_at,payment_type,payment_total
 custom_calendar_sql = """
 {{ config(materialized='table') }}
 with days as (
-    {{ dbt_utils.date_spine(
+    {{ metrics.metric_date_spine(
     datepart="day",
     start_date="cast('2010-01-01' as date)",
     end_date="cast('2030-01-01' as date)"

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -147,7 +147,10 @@ models:
 # packages.yml
 packages_yml = """
   - package: calogica/dbt_expectations
-    version: [">=0.5.0", "<0.6.0"]
+    version: [">=0.6.0", "<0.7.0"]
+
+  - package: dbt-labs/dbt_utils
+    version: [">=0.9.0", "<1.0.0"]
 """
 
 # seeds/events.csv

--- a/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
+++ b/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
@@ -59,7 +59,7 @@ version: 2
 models:
   - name: base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_sum_metric__expected')
 metrics:
   - name: base_sum_metric

--- a/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
+++ b/tests/functional/invalid_configs/test_invalid_calendar_dim_without_param.py
@@ -13,7 +13,7 @@ from tests.functional.fixtures import (
 # models/custom_calendar.sql
 custom_calendar_sql = """
 with days as (
-    {{ dbt_utils.date_spine(
+    {{ metrics.metric_date_spine(
     datepart="day",
     start_date="cast('2010-01-01' as date)",
     end_date="cast('2030-01-01' as date)"

--- a/tests/functional/invalid_configs/test_invalid_dimension.py
+++ b/tests/functional/invalid_configs/test_invalid_dimension.py
@@ -58,7 +58,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/invalid_configs/test_invalid_period_to_date_average.py
+++ b/tests/functional/invalid_configs/test_invalid_period_to_date_average.py
@@ -29,7 +29,7 @@ version: 2
 models:
   - name: invalid_period_to_date_average
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('invalid_period_to_date_average__expected')
 metrics:
   - name: invalid_period_to_date_average

--- a/tests/functional/invalid_configs/test_invalid_time_grain.py
+++ b/tests/functional/invalid_configs/test_invalid_time_grain.py
@@ -57,7 +57,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/invalid_configs/test_invalid_where.py
+++ b/tests/functional/invalid_configs/test_invalid_where.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: invalid_where
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('invalid_where__expected')
 metrics:
   - name: invalid_where

--- a/tests/functional/metric_options/all_time/test_all_time.py
+++ b/tests/functional/metric_options/all_time/test_all_time.py
@@ -42,7 +42,7 @@ version: 2
 models:
   - name: metric_on_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('metric_on_derived_metric__expected')
 metrics:
   - name: derived_metric

--- a/tests/functional/metric_options/calendar_dimensions/test_custom_calendar_dimensions.py
+++ b/tests/functional/metric_options/calendar_dimensions/test_custom_calendar_dimensions.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_sum_metric__expected')
 metrics:
   - name: base_sum_metric

--- a/tests/functional/metric_options/case_when/test_case_when_metric.py
+++ b/tests/functional/metric_options/case_when/test_case_when_metric.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: case_when_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('case_when_metric__expected')
 metrics:
   - name: case_when_metric

--- a/tests/functional/metric_options/date_grains/test_day_grain.py
+++ b/tests/functional/metric_options/date_grains/test_day_grain.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: day_grain_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('day_grain__expected')
 metrics:
   - name: day_grain_metric

--- a/tests/functional/metric_options/date_grains/test_month_grain.py
+++ b/tests/functional/metric_options/date_grains/test_month_grain.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: month_grain_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('month_grain__expected')
 metrics:
   - name: month_grain_metric

--- a/tests/functional/metric_options/date_grains/test_week_grain.py
+++ b/tests/functional/metric_options/date_grains/test_week_grain.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: week_grain_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('week_grain__expected')
 metrics:
   - name: week_grain_metric

--- a/tests/functional/metric_options/dimensions/test_multi_dimension_base_metric.py
+++ b/tests/functional/metric_options/dimensions/test_multi_dimension_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: multi_dimension_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multi_dimension_base_sum_metric__expected')
 metrics:
   - name: multi_dimension_base_sum_metric

--- a/tests/functional/metric_options/dimensions/test_multi_dimension_derived_metric.py
+++ b/tests/functional/metric_options/dimensions/test_multi_dimension_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: multi_dimension_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multi_dimension_derived_metric__expected')
 metrics:
   - name: multi_dimension_derived_metric

--- a/tests/functional/metric_options/dimensions/test_single_dimension_base_metric.py
+++ b/tests/functional/metric_options/dimensions/test_single_dimension_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: single_dimension_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('single_dimension_base_sum_metric__expected')
 metrics:
   - name: single_dimension_base_sum_metric

--- a/tests/functional/metric_options/dimensions/test_single_dimension_derived_metric.py
+++ b/tests/functional/metric_options/dimensions/test_single_dimension_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: single_dimension_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('single_dimension_derived_metric__expected')
 metrics:
   - name: single_dimension_derived_metric

--- a/tests/functional/metric_options/end_date/test_early_end_date_base_metric.py
+++ b/tests/functional/metric_options/end_date/test_early_end_date_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: early_end_date_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('early_end_date_base_sum_metric__expected')
 metrics:
   - name: early_end_date_base_sum_metric

--- a/tests/functional/metric_options/end_date/test_early_end_date_derived_metric.py
+++ b/tests/functional/metric_options/end_date/test_early_end_date_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: end_date_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('end_date_derived_metric__expected')
 metrics:
   - name: end_date_derived_metric

--- a/tests/functional/metric_options/end_date/test_end_date_base_metric.py
+++ b/tests/functional/metric_options/end_date/test_end_date_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: end_date_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('end_date_base_sum_metric__expected')
 metrics:
   - name: end_date_base_sum_metric

--- a/tests/functional/metric_options/end_date/test_end_date_derived_metric.py
+++ b/tests/functional/metric_options/end_date/test_end_date_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: end_date_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('end_date_derived_metric__expected')
 metrics:
   - name: end_date_derived_metric

--- a/tests/functional/metric_options/metric_reference/test_double_quote_ref_name.py
+++ b/tests/functional/metric_options/metric_reference/test_double_quote_ref_name.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: double_quote_ref_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('double_quote_ref_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types_dimensions.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_base_types_dimensions.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_derived_types.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_derived_types.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: derived_metric

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_derived_types_dimensions.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_derived_types_dimensions.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: derived_metric

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_outer_join.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_outer_join.py
@@ -30,7 +30,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 
 metrics:

--- a/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_secondary_calcs.py
+++ b/tests/functional/metric_options/multiple_metrics/test_multiple_metrics_secondary_calcs.py
@@ -44,7 +44,7 @@ version: 2
 models:
   - name: multiple_metrics
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('multiple_metrics__expected')
 metrics:
   - name: base_count_metric

--- a/tests/functional/metric_options/old_metric_spec/test_old_metric_spec.py
+++ b/tests/functional/metric_options/old_metric_spec/test_old_metric_spec.py
@@ -26,7 +26,7 @@ version: 2
 models:
   - name: old_spec_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('old_spec_metric__expected')
 metrics:
   - name: old_spec_metric

--- a/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_difference.py
+++ b/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_difference.py
@@ -29,7 +29,7 @@ version: 2
 models:
   - name: period_over_period_difference
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_over_period_difference__expected')
 metrics:
   - name: period_over_period_difference

--- a/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_ratio.py
+++ b/tests/functional/metric_options/secondary_calculations/period_over_period/test_period_over_period_ratio.py
@@ -29,7 +29,7 @@ version: 2
 models:
   - name: period_over_period_ratio
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_over_period_ratio__expected')
 metrics:
   - name: period_over_period_ratio

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_average.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_average.py
@@ -30,7 +30,7 @@ version: 2
 models:
   - name: period_to_date_average
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_average__expected')
 metrics:
   - name: period_to_date_average

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: period_to_date_count
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_count__expected')
 metrics:
   - name: period_to_date_count

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count_distinct.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_count_distinct.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: period_to_date_count_distinct
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_count_distinct__expected')
 metrics:
   - name: period_to_date_count_distinct

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_derived.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_derived.py
@@ -47,7 +47,7 @@ version: 2
 models:
   - name: period_to_date_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_derived_metric__expected')
 metrics:
   - name: period_to_date_derived_metric

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_max.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_max.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: period_to_date_max
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_max__expected')
 metrics:
   - name: period_to_date_max

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_min.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_min.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: period_to_date_min
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_min__expected')
 metrics:
   - name: period_to_date_min

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_same_period_and_grain.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_same_period_and_grain.py
@@ -29,7 +29,7 @@ version: 2
 models:
   - name: same_period_and_grain
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('same_period_and_grain__expected')
 metrics:
   - name: same_period_and_grain

--- a/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_sum.py
+++ b/tests/functional/metric_options/secondary_calculations/period_to_date/test_period_to_date_sum.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: period_to_date_sum
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('period_to_date_sum__expected')
 metrics:
   - name: period_to_date_sum

--- a/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
+++ b/tests/functional/metric_options/secondary_calculations/prior/test_prior.py
@@ -29,7 +29,7 @@ version: 2
 models:
   - name: prior_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('prior_metric__expected')
 metrics:
   - name: prior_metric

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_average.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_average.py
@@ -30,7 +30,7 @@ version: 2
 models:
   - name: rolling_average
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_average__expected')
 metrics:
   - name: rolling_average

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: rolling_count
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_count__expected')
 metrics:
   - name: rolling_count

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count_distinct.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_count_distinct.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: rolling_count_distinct
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_count_distinct__expected')
 metrics:
   - name: rolling_count_distinct

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_derived.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_derived.py
@@ -47,7 +47,7 @@ version: 2
 models:
   - name: rolling_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_derived_metric__expected')
 metrics:
   - name: rolling_derived_metric

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_max.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_max.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: rolling_max
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_max__expected')
 metrics:
   - name: rolling_max

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_min.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_min.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: rolling_min
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_min__expected')
 metrics:
   - name: rolling_min

--- a/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_sum.py
+++ b/tests/functional/metric_options/secondary_calculations/rolling/test_rolling_sum.py
@@ -32,7 +32,7 @@ version: 2
 models:
   - name: rolling_sum
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('rolling_sum__expected')
 metrics:
   - name: rolling_sum

--- a/tests/functional/metric_options/start_date/test_late_start_date_base_metric.py
+++ b/tests/functional/metric_options/start_date/test_late_start_date_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: late_start_date_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('late_start_date_base_sum_metric__expected')
 metrics:
   - name: late_start_date_base_sum_metric

--- a/tests/functional/metric_options/start_date/test_late_start_date_derived_metric.py
+++ b/tests/functional/metric_options/start_date/test_late_start_date_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: late_start_date_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('late_start_date_derived_metric__expected')
 metrics:
   - name: late_start_date_derived_metric

--- a/tests/functional/metric_options/start_date/test_start_date_base_metric.py
+++ b/tests/functional/metric_options/start_date/test_start_date_base_metric.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: start_date_base_sum_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('start_date_base_sum_metric__expected')
 metrics:
   - name: start_date_base_sum_metric

--- a/tests/functional/metric_options/start_date/test_start_date_derived_metric.py
+++ b/tests/functional/metric_options/start_date/test_start_date_derived_metric.py
@@ -43,7 +43,7 @@ version: 2
 models:
   - name: start_date_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('start_date_derived_metric__expected')
 metrics:
   - name: start_date_derived_metric

--- a/tests/functional/metric_options/treat_null_values_as_zero/test_treat_null_values_as_zero.py
+++ b/tests/functional/metric_options/treat_null_values_as_zero/test_treat_null_values_as_zero.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: treat_null_values_as_zero
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('treat_null_values_as_zero__expected')
 metrics:
   - name: treat_null_values_as_zero

--- a/tests/functional/metric_options/where/test_where_base_metric.py
+++ b/tests/functional/metric_options/where/test_where_base_metric.py
@@ -28,7 +28,7 @@ version: 2
 models:
   - name: where_base_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('where_base_metric__expected')
 metrics:
   - name: where_base_metric

--- a/tests/functional/metric_options/where/test_where_derived_metric.py
+++ b/tests/functional/metric_options/where/test_where_derived_metric.py
@@ -44,7 +44,7 @@ version: 2
 models:
   - name: where_derived_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('where_derived_metric__expected')
 metrics:
   - name: where_derived_metric

--- a/tests/functional/metric_options/window/test_window_day.py
+++ b/tests/functional/metric_options/window/test_window_day.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: base_window_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_window_metric__expected')
 metrics:
   - name: base_window_metric

--- a/tests/functional/metric_options/window/test_window_month.py
+++ b/tests/functional/metric_options/window/test_window_month.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: base_window_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_window_metric__expected')
 metrics:
   - name: base_window_metric

--- a/tests/functional/metric_options/window/test_window_week.py
+++ b/tests/functional/metric_options/window/test_window_week.py
@@ -27,7 +27,7 @@ version: 2
 models:
   - name: base_window_metric
     tests: 
-      - dbt_utils.equality:
+      - metrics.metric_equality:
           compare_model: ref('base_window_metric__expected')
 metrics:
   - name: base_window_metric


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
I am removing the `dbt_utils` dependency based on issues raised here #139 . We want to make this as simple as possible for users to take advantage of metrics and removing complexity is the first step.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
