### PR TITLE
fix issue #146 - using the metric window functionality with time_grain='day'

### DIFF
--- a/.changes/unreleased/Fixes-20221025-164009.yaml
+++ b/.changes/unreleased/Fixes-20221025-164009.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixing bug with window functionality
+time: 2022-10-25T16:40:09.927002+01:00
+custom:
+  Author: JoeryV
+  Issue: "146"
+  PR: "149"

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -14,7 +14,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain != 'day' %}
+            {% if grain %}
             calendar_table.date_day as window_filter_date,
             {% endif %}
 
@@ -91,7 +91,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain != 'day' %}
+            {% if grain %}
             calendar_table.date_day as window_filter_date,
             {% endif %}
 
@@ -168,7 +168,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
             
-            {% if grain != 'day' %}
+            {% if grain %}
             calendar_table.date_day as window_filter_date,
             {% endif %}
 
@@ -242,7 +242,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain != 'day' %}
+            {% if grain %}
             calendar_table.date_day as window_filter_date,
             {% endif %}
 

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -14,9 +14,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain %}
             calendar_table.date_day as window_filter_date,
-            {% endif %}
 
             {% if secondary_calculations | length > 0 -%}
                 {%- for period in relevant_periods %}
@@ -91,9 +89,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain %}
             calendar_table.date_day as window_filter_date,
-            {% endif %}
 
             {% if secondary_calculations | length > 0 -%}
                 {%- for period in relevant_periods %}
@@ -168,9 +164,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
             
-            {% if grain %}
             calendar_table.date_day as window_filter_date,
-            {% endif %}
 
             {% if secondary_calculations | length > 0 -%}
                 {%- for period in relevant_periods %}
@@ -242,9 +236,7 @@
             calendar_table.date_{{ grain }} as date_{{grain}},
             {% endif -%}
 
-            {% if grain %}
             calendar_table.date_day as window_filter_date,
-            {% endif %}
 
             {% if secondary_calculations | length > 0 -%}
                 {%- for period in relevant_periods %}


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change


## Description & motivation
This PR fixes the bug described in issue #146. 
The `window_filter_date` will now be added regardless of the `time_grain` specified upon calling the metric.

How? The if condition that witheld the `window_filter_date` field from being added to the compiled query in case of `time_grain='day'` has been removed.


## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
