### PR TITLE
Update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 3. [Getting the code](#getting-the-code)
 4. [Running `dbt_metrics` in development](#running-dbtmetrics-in-development)
 6. [Testing](#testing)
+7. [Adding a changelog entry](#adding-a-changelog-entry)
 7. [Submitting a Pull Request](#submitting-a-pull-request)
 
 ## About this document
@@ -153,6 +154,16 @@ python3 -m pytest tests/functional/example/test_example_failing_test.py
 ```shell
 python3 -m pytest tests/functional
 ```
+
+## Adding a CHANGELOG Entry
+
+We use [changie](https://changie.dev) to generate `CHANGELOG` entries. **Note:** Do not edit the `CHANGELOG.md` directly. Your modifications will be lost.
+
+Follow the steps to [install `changie`](https://changie.dev/guide/installation/) for your system.
+
+Once changie is installed and your PR is created, simply run `changie new` and changie will walk you through the process of creating a changelog entry.  Commit the file that's created and your changelog entry is complete!
+
+You don't need to worry about which `dbt_metrics` version your change will go into. Just create the changelog entry with `changie`, and open your PR against the `main` branch. All merged changes will be included in the next minor version of `dbt_metrics`. The metrics maintainers _may_ choose to "backport" specific changes in order to patch older minor versions. In that case, a maintainer will take care of that backport after merging your PR, before releasing the new version of `dbt_metrics`.
 
 ## Submitting a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 4. [Running `dbt_metrics` in development](#running-dbtmetrics-in-development)
 6. [Testing](#testing)
 7. [Adding a changelog entry](#adding-a-changelog-entry)
-7. [Submitting a Pull Request](#submitting-a-pull-request)
+8. [Submitting a Pull Request](#submitting-a-pull-request)
 
 ## About this document
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Copy the changie heading from `dbt-core` into the CONTRIBUTING.md docs in `dbt_metrics`. The devs expects it to be there, so should be added.


## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
