### PR TITLE
[SEMANTIC-59] [Bug] metric_jsonschema_example still references old properties in required fields

### DIFF
--- a/.changes/unreleased/Fixes-20221102-232947.yaml
+++ b/.changes/unreleased/Fixes-20221102-232947.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Updated the example metric_json_schema.yml file to reference the new properties.
+time: 2022-11-02T23:29:47.135949+02:00
+custom:
+  Author: rijnhardtkotze
+  Issue: "176"
+  PR: "177"

--- a/examples/metric_jsonschema_example.json
+++ b/examples/metric_jsonschema_example.json
@@ -1,7 +1,7 @@
 {
     "title": "dbt_metric_file",
     "type": "object",
-    "required": ["name","label","timestamp","time_grains","type","sql"],
+    "required": ["name","label","timestamp","time_grains","calculation_method","expression"],
     "additionalProperties": false,
     "properties": {
         "name": { "type": "string"},


### PR DESCRIPTION
Signed-off-by: Rijnhardt Kotze <me@rijnhardt.co.za>


## What is this PR?
This is a:
- [x] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->
Changing the required properties to reference the new properties.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
