### PR TITLE
Update README.md calendar model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,13 @@ The package comes with a [basic calendar table](/models/dbt_metrics_default_cale
 - Contains the following columns: `date_week`, `date_month`, `date_quarter`, `date_year`, or equivalents. 
 - Additional date columns need to be prefixed with `date_`, e.g. `date_4_5_4_month` for a 4-5-4 retail calendar date set. Dimensions can have any name (see [dimensions on calendar tables](#dimensions-on-calendar-tables)).
 
-To do this, set the value of the `dbt_metrics_calendar_model` variable in your `dbt_project.yml` file: 
+To do this, set the value of the `dbt_metrics_default_calendar` variable in your `dbt_project.yml` file: 
 ```yaml
 #dbt_project.yml
 config-version: 2
 [...]
 vars:
-    dbt_metrics_calendar_model: my_custom_calendar
+    dbt_metrics_default_calendar: my_custom_calendar
 ```
 
 ### Dimensions from calendar tables


### PR DESCRIPTION
fixed typo in docs.getdbt.com [PR](https://github.com/dbt-labs/docs.getdbt.com/pull/2624) per slack thread [here](https://getdbt.slack.com/archives/C02CCBBBR1D/p1671520139657599) and [here](https://dbt-labs.slack.com/archives/C04437Z6M5F/p1671550094676819). 

noticed the project readme still had the `dbt_metrics_calendar_model` and am proposing changes to reflect the correct model name `dbt_metrics_default_calendar`. However, if this doesn't make sense for the project.yml file instructions, then please do let me know


## What is this PR?
This is a:
- [x ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
