### PR TITLE
Let There Be Median

### DIFF
--- a/.changes/unreleased/Features-20230109-145530.yaml
+++ b/.changes/unreleased/Features-20230109-145530.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Adding median
+time: 2023-01-09T14:55:30.09271-06:00
+custom:
+  Author: callum-mcdata
+  Issue: "180"
+  PR: "208"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "dbt_metrics_integration_tests_postgres"
+profile: "dbt_metrics_integration_tests_bigquery"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "dbt_metrics_integration_tests_bigquery"
+profile: "dbt_metrics_integration_tests_postgres"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/integration_tests/models/metric_definitions/base_median_metric.yml
+++ b/integration_tests/models/metric_definitions/base_median_metric.yml
@@ -1,0 +1,14 @@
+version: 2 
+metrics:
+  - name: base_median_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month, all_time]
+    calculation_method: median
+    expression: discount_total
+    dimensions:
+      - had_discount
+      - order_country
+
+    

--- a/integration_tests/models/metric_testing_models/base_median_metric.sql
+++ b/integration_tests/models/metric_testing_models/base_median_metric.sql
@@ -1,0 +1,6 @@
+select *
+from 
+{{ metrics.calculate(metric('base_median_metric'), 
+    grain='month', 
+    dimensions=['had_discount']) 
+}}

--- a/integration_tests/models/metric_testing_models/base_median_metric_no_time_grain.sql
+++ b/integration_tests/models/metric_testing_models/base_median_metric_no_time_grain.sql
@@ -1,0 +1,5 @@
+select *
+from 
+{{ metrics.calculate(metric('base_median_metric'), 
+    dimensions=['had_discount']) 
+}}

--- a/macros/calculate.sql
+++ b/macros/calculate.sql
@@ -7,7 +7,7 @@
     {#- Need this here, since the actual ref is nested within loops/conditions: -#}
     -- depends on: {{ ref(var('dbt_metrics_calendar_model', 'dbt_metrics_default_calendar')) }}
     
-    {# ############
+    {#- ############
     VARIABLE SETTING - Creating the metric tree and making sure metric list is a list!
     ############ -#}
 

--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -48,13 +48,10 @@ metrics there are -#}
     start_date=start_date, 
     end_date=end_date) 
     }}
-
 {#- Next we check if it is a composite metric or single metric by checking the length of the list -#}
 {#- This filter forms the basis of how we construct the SQL -#}
-
 {#- If composite, we begin by looping through each of the metric names that make
 up the composite metric. -#}
-
 {%- for metric_name in metric_tree["parent_set"] -%}
 
     {{ metrics.build_metric_sql(

--- a/macros/sql_gen/build_metric_sql.sql
+++ b/macros/sql_gen/build_metric_sql.sql
@@ -1,5 +1,5 @@
 {%- macro build_metric_sql(metric_dictionary, grain, dimensions, secondary_calculations, start_date, end_date, calendar_tbl, relevant_periods, calendar_dimensions, dimensions_provided, total_dimension_count) %}
-    
+
     {%- set treat_null_values_as_zero = metric_dictionary.get("config").get("treat_null_values_as_zero", True)  -%}
     {#- This is the SQL Gen part - we've broken each component out into individual macros -#}
     {#- We broke this out so it can loop for composite metrics -#}
@@ -28,7 +28,6 @@
         
         {%- endif -%}
 
-
         {{ metrics.gen_spine_time_cte(
             metric_name=metric_dictionary.name, 
             grain=grain, 
@@ -53,4 +52,4 @@
         treat_null_values_as_zero=treat_null_values_as_zero
     )}} 
 
-{% endmacro -%}
+{%- endmacro -%}

--- a/macros/sql_gen/gen_aggregate_cte.sql
+++ b/macros/sql_gen/gen_aggregate_cte.sql
@@ -9,6 +9,7 @@
     and THEN aggregating, we are instead aggregating from the beginning and then 
     joining downstream for performance. Additionally, we're using a subquery instead 
     of a CTE, which was significantly more performant during our testing. -#}
+    {#- #}
     select
 
         {%- if grain %}
@@ -37,12 +38,11 @@
 
         {%- if grain %}
         {{ bool_or('metric_date_day is not null') }} as has_data,
-        {% endif %}
+        {%- endif %}
 
         {#- This line performs the relevant aggregation by calling the 
         gen_primary_metric_aggregate macro. Take a look at that one if you're curious -#}
         {{ metrics.gen_primary_metric_aggregate(metric_dictionary.calculation_method, 'property_to_aggregate') }} as {{ metric_dictionary.name }}
-
     from ({{ metrics.gen_base_query(
                 metric_dictionary=metric_dictionary,
                 grain=grain, 
@@ -57,11 +57,9 @@
     ) as base_query
 
     where 1=1
-
-    {% if metric_dictionary.window is not none and grain %}
+    {%- if metric_dictionary.window is not none and grain %}
     and date_{{grain}} = window_filter_date
-    {% endif %}
-
+    {%- endif %}
     {{ metrics.gen_group_by(grain, dimensions, calendar_dimensions, relevant_periods) }}
 
 )

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -3,12 +3,10 @@
 {% endmacro %}
 
 {% macro default__gen_base_query(metric_dictionary, grain, dimensions, secondary_calculations, start_date, end_date, calendar_tbl, relevant_periods, calendar_dimensions, total_dimension_count) %}
-
         {# This is the "base" CTE which selects the fields we need to correctly 
-        calculate the metric.  #}
+        calculate the metric.  -#}
         select 
-    
-            {% if grain %}
+            {% if grain -%}
             cast(base_model.{{metric_dictionary.timestamp}} as date) as metric_date_day,
             calendar_table.date_{{ grain }} as date_{{grain}},
             calendar_table.date_day as window_filter_date,
@@ -17,26 +15,23 @@
             calendar_table.date_{{ period }},
                     {% endfor -%}
                 {%- endif -%}
-            {%- endif -%}
-
-            {% for dim in dimensions %}
+            {%- endif %}
+            {#- -#}
+            {%- for dim in dimensions -%}
             base_model.{{ dim }},
-            {% endfor %}
-
-            {% for calendar_dim in calendar_dimensions %}
+            {%- endfor -%}
+            {%- for calendar_dim in calendar_dimensions -%}
             calendar_table.{{ calendar_dim }},
-            {% endfor %}
-
-            {{ metrics.gen_property_to_aggregate(metric_dictionary, grain, dimensions, calendar_dimensions)}}
-
+            {%- endfor -%}
+            {{ metrics.gen_property_to_aggregate(metric_dictionary, grain, dimensions, calendar_dimensions) }}
         from {{ metric_dictionary.metric_model }} base_model 
-        
-        {% if grain or calendar_dimensions|length > 0 %}
+        {# -#}
+        {%- if grain or calendar_dimensions|length > 0 -%}
         {{ metrics.gen_calendar_table_join(metric_dictionary, calendar_tbl) }} 
-        {% endif %}
-
+        {%- endif -%}
+        {# #}
         where 1=1
-        
+        {#- -#}
         {{ metrics.gen_filters(metric_dictionary, start_date, end_date) }}
 
 {%- endmacro -%}

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -27,17 +27,7 @@
             calendar_table.{{ calendar_dim }},
             {% endfor %}
 
-
-            {%- if metric_dictionary.expression and metric_dictionary.expression | replace('*', '') | trim != '' %}
-
-            ({{ metric_dictionary.expression }}) as property_to_aggregate
-            {%- elif metric_dictionary.calculation_method == 'count' -%} 
-            {# We use 1 as the property to aggregate in count so that it matches count(*) #}
-            1 as property_to_aggregate 
-            {%- else -%}
-                {%- do exceptions.raise_compiler_error("Expression to aggregate is required for non-count aggregation in metric `" ~ metric_dictionary.name ~ "`") -%}  
-            {%- endif %}
-
+            {{ metrics.gen_property_to_aggregate(metric_dictionary, grain, dimensions, calendar_dimensions)}}
 
         from {{ metric_dictionary.metric_model }} base_model 
         

--- a/macros/sql_gen/gen_calendar_cte.sql
+++ b/macros/sql_gen/gen_calendar_cte.sql
@@ -5,7 +5,6 @@
 {%- macro default__gen_calendar_cte(calendar_tbl, start_date, end_date) %}
 
 with calendar as (
-
     {# This CTE creates our base calendar and then limits the date range for the 
     start and end date provided by the macro call -#}
     select 
@@ -23,4 +22,4 @@ with calendar as (
     {% endif %} 
 )
 
-{% endmacro %}
+{%- endmacro -%}

--- a/macros/sql_gen/gen_calendar_table_join.sql
+++ b/macros/sql_gen/gen_calendar_table_join.sql
@@ -1,51 +1,43 @@
 {% macro gen_calendar_table_join(metric_dictionary, calendar_tbl) %}
     {{ return(adapter.dispatch('gen_calendar_table_join', 'metrics')(metric_dictionary, calendar_tbl)) }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__gen_calendar_table_join(metric_dictionary, calendar_tbl) %}
-
     left join {{calendar_tbl}} calendar_table
-    {% if metric_dictionary.window is not none %}
+    {%- if metric_dictionary.window is not none -%}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) > dateadd({{metric_dictionary.window.period}}, -{{metric_dictionary.window.count}}, calendar_table.date_day)
         and cast(base_model.{{metric_dictionary.timestamp}} as date) <= calendar_table.date_day
-    {% else %}
+    {%- else %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) = calendar_table.date_day
-    {% endif %}
-
+    {% endif -%}
 {% endmacro %}
 
 {% macro bigquery__gen_calendar_table_join(metric_dictionary, calendar_tbl) %}
-
     left join {{calendar_tbl}} calendar_table
-    {% if metric_dictionary.window is not none %}
+    {%- if metric_dictionary.window is not none %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) > date_sub(calendar_table.date_day, interval {{metric_dictionary.window.count}} {{metric_dictionary.window.period}})
         and cast(base_model.{{metric_dictionary.timestamp}} as date) <= calendar_table.date_day
-    {% else %}
+    {%- else %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) = calendar_table.date_day
-    {% endif %}
-
+    {% endif -%}
 {% endmacro %}
 
 {% macro postgres__gen_calendar_table_join(metric_dictionary, calendar_tbl) %}
-
     left join {{calendar_tbl}} calendar_table
-    {% if metric_dictionary.window is not none %}
+    {%- if metric_dictionary.window is not none %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) > calendar_table.date_day - interval '{{metric_dictionary.window.count}} {{metric_dictionary.window.period}}'
         and cast(base_model.{{metric_dictionary.timestamp}} as date) <= calendar_table.date_day
-    {% else %}
+    {%- else %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) = calendar_table.date_day
-    {% endif %}
-
+    {% endif -%}
 {% endmacro %}
 
 {% macro redshift__gen_calendar_table_join(metric_dictionary, calendar_tbl) %}
-
     left join {{calendar_tbl}} calendar_table
-    {% if metric_dictionary.window is not none %}
+    {%- if metric_dictionary.window is not none %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) > dateadd({{metric_dictionary.window.period}}, -{{metric_dictionary.window.count}}, calendar_table.date_day)
         and cast(base_model.{{metric_dictionary.timestamp}} as date) <= calendar_table.date_day
-    {% else %}
+    {%- else %}
         on cast(base_model.{{metric_dictionary.timestamp}} as date) = calendar_table.date_day
-    {% endif %}
-
+    {% endif -%}
 {% endmacro %}

--- a/macros/sql_gen/gen_metric_cte.sql
+++ b/macros/sql_gen/gen_metric_cte.sql
@@ -5,7 +5,7 @@
 {%- macro default__gen_metric_cte(metric_name, grain, dimensions, secondary_calculations, start_date, end_date, relevant_periods, calendar_dimensions, treat_null_values_as_zero) %}
 
 , {{metric_name}}__final as (
-
+    {# #}
     {%- if not treat_null_values_as_zero -%}
         {%- set metric_val = metric_name -%}
     {%- else -%}
@@ -15,9 +15,8 @@
             {%- set metric_val = "coalesce(" ~ metric_name ~ ", 0) as " ~ metric_name -%}
         {%- endif %}
     {%- endif %}
-    
     select
-        {% if grain %}
+        {%- if grain %}
         parent_metric_cte.date_{{grain}},
             {%- if secondary_calculations | length > 0 -%}
                 {% for period in relevant_periods %}
@@ -78,13 +77,10 @@
         )      
         {% endif %} 
 
-    {% else %}
-
+    {%- else %}
     from {{metric_name}}__aggregate as parent_metric_cte
-
-
     {% endif -%}
-
+    {# #}
 )
 
 {% endmacro %}

--- a/macros/sql_gen/gen_primary_metric_aggregate.sql
+++ b/macros/sql_gen/gen_primary_metric_aggregate.sql
@@ -23,6 +23,9 @@
     {%- elif aggregate == 'sum' -%}
         {{ return(adapter.dispatch('metric_sum', 'metrics')(expression)) }}
 
+    {%- elif aggregate == 'median' -%}
+        {{ return(adapter.dispatch('metric_median', 'metrics')(expression)) }}
+
     {%- elif aggregate == 'derived' -%}
         {{ return(adapter.dispatch('metric_derived', 'metrics')(expression)) }}
 
@@ -57,6 +60,18 @@
 
 {% macro default__metric_sum(expression) %}
         sum({{ expression }})
+{%- endmacro -%}
+
+{% macro default__metric_median(expression) %}
+        median({{ expression }})
+{%- endmacro -%}
+
+{% macro bigquery__metric_median(expression) %}
+        any_value({{ expression }})
+{%- endmacro -%}
+
+{% macro postgres__metric_median(expression) %}
+        percentile_cont(0.5) within group (order by {{ expression }})
 {%- endmacro -%}
 
 {% macro default__metric_derived(expression) %}

--- a/macros/sql_gen/gen_property_to_aggregate.sql
+++ b/macros/sql_gen/gen_property_to_aggregate.sql
@@ -1,0 +1,61 @@
+{%- macro gen_property_to_aggregate(metric_dictionary, grain, dimensions, calendar_dimensions) -%}
+    {{ return(adapter.dispatch('gen_property_to_aggregate', 'metrics')(metric_dictionary, grain, dimensions, calendar_dimensions)) }}
+{%- endmacro -%}
+
+{% macro default__gen_property_to_aggregate(metric_dictionary, grain, dimensions, calendar_dimensions) %}
+
+    -- WE NEED DIMS, CALENDAR DIMS, AND GRAIN
+
+    {%- if metric_dictionary.calculation_method == 'median' -%}
+        {{ return(adapter.dispatch('property_to_aggregate_median', 'metrics')(metric_dictionary.expression, grain, dimensions, calendar_dimensions)) }}
+
+    {%- elif metric_dictionary.calculation_method == 'count' -%}
+        {{ return(adapter.dispatch('property_to_aggregate_count', 'metrics')()) }}
+
+    {%- elif metric_dictionary.expression and metric_dictionary.expression | replace('*', '') | trim != '' %}
+        {{ return(adapter.dispatch('property_to_aggregate_default', 'metrics')(metric_dictionary.expression)) }}
+
+    {%- else -%}
+        {%- do exceptions.raise_compiler_error("Expression to aggregate is required for non-count aggregation in metric `" ~ metric_dictionary.name ~ "`") -%}  
+    {%- endif %}
+
+{% endmacro %}
+
+{% macro default__property_to_aggregate_median(expression, grain, dimensions, calendar_dimensions) %}
+    ({{expression }}) as property_to_aggregate
+{%- endmacro -%}
+
+{% macro bigquery__property_to_aggregate_median(expression, grain, dimensions, calendar_dimensions) %}
+
+    percentile_cont({{expression }}, 0.5) over (
+        partition by 
+        {%- if grain %}
+        calendar_table.date_{{ grain }}
+        {% endif -%}
+        
+        {%- for dim in dimensions %}
+            {%- if loop.first and not grain -%}
+        base_model.{{ dim }}
+            {%- else -%}
+        ,base_model.{{ dim }}
+            {%- endif -%}
+        {% endfor -%}
+        
+        {%- for calendar_dim in calendar_dimensions %}
+            {%- if loop.first and dimensions | length == 0 and not grain -%}
+        calendar_table.{{ calendar_dim }}
+            {%- else -%}
+        ,calendar_table.{{ calendar_dim }}
+            {%- endif -%}
+        {% endfor -%}
+    ) as property_to_aggregate
+
+{%- endmacro -%}
+
+{% macro default__property_to_aggregate_count() %}
+    1 as property_to_aggregate
+{%- endmacro -%}
+
+{% macro default__property_to_aggregate_default(expression) %}
+    ({{expression }}) as property_to_aggregate
+{%- endmacro -%}

--- a/tests/functional/calculation_methods/test_median.py
+++ b/tests/functional/calculation_methods/test_median.py
@@ -1,0 +1,304 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml
+)
+
+# models/base_median_metric.sql
+base_median_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('base_median_metric'), 
+    grain='month'
+    )
+}}
+"""
+
+# models/base_median_metric.yml
+base_median_metric_yml = """
+version: 2 
+models:
+  - name: base_median_metric
+    tests: 
+      - metrics.metric_equality:
+          compare_model: ref('base_median_metric__expected')
+metrics:
+  - name: base_median_metric
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    calculation_method: median
+    expression: discount_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/base_median_metric__expected.csv
+base_median_metric__expected_csv = """
+date_month,base_median_metric
+2022-01-01,1
+2022-02-01,1
+""".lstrip()
+
+class TestBaseMedianMetric:
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "base_median_metric__expected.csv": base_median_metric__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "base_median_metric.sql": base_median_metric_sql,
+            "base_median_metric.yml": base_median_metric_yml
+        }
+
+    def test_base_median_metric(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]
+
+# models/base_median_metric_no_time_grain.sql
+base_median_metric_no_time_grain_sql = """
+select *
+from 
+{{ metrics.calculate(metric('base_median_metric_no_time_grain'))
+}}
+"""
+
+# models/base_median_metric_no_time_grain.yml
+base_median_metric_no_time_grain_yml = """
+version: 2 
+models:
+  - name: base_median_metric_no_time_grain
+    tests: 
+      - metrics.metric_equality:
+          compare_model: ref('base_median_metric_no_time_grain__expected')
+metrics:
+  - name: base_median_metric_no_time_grain
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    calculation_method: median
+    expression: discount_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/base_median_metric_no_time_grain__expected.csv
+base_median_metric_no_time_grain__expected_csv = """
+base_median_metric_no_time_grain
+1
+""".lstrip()
+
+class TestBaseMedianMetricNoTimeGrain:
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv,
+            "base_median_metric_no_time_grain__expected.csv": base_median_metric_no_time_grain__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "base_median_metric_no_time_grain.sql": base_median_metric_no_time_grain_sql,
+            "base_median_metric_no_time_grain.yml": base_median_metric_no_time_grain_yml
+        }
+
+    def test_base_median_metric_no_time_grain(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]
+
+
+# seeds/complicated_median_source.csv
+complicated_median_source_csv = """
+order_id,order_country,had_discount,customer_id,order_date,order_total
+4,France,true,3,2022-01-06,1.43
+5,France,false,4,2022-01-08,4.29
+3,France,false,1,2022-01-13,6.56
+2,Japan,false,2,2022-01-20,5.93
+6,Japan,false,5,2022-01-21,1.01
+7,Japan,true,2,2022-01-22,2.7
+1,France,false,1,2022-01-28,3.34
+9,Japan,false,2,2022-02-03,7.11
+10,Japan,false,3,2022-02-13,5.89
+8,France,true,1,2022-02-15,9.12
+""".lstrip()
+
+# models/base_median_metric_complicated_source.sql
+base_median_metric_complicated_source_sql = """
+select *
+from 
+{{ metrics.calculate(metric('base_median_metric_complicated_source'),
+    grain='month'
+    )
+}}
+"""
+
+# models/base_median_metric_complicated_source.yml
+base_median_metric_complicated_source_yml = """
+version: 2 
+models:
+  - name: base_median_metric_complicated_source
+    tests: 
+      - metrics.metric_equality:
+          compare_model: ref('base_median_metric_complicated_source__expected')
+metrics:
+  - name: base_median_metric_complicated_source
+    model: ref('fact_orders')
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    calculation_method: median
+    expression: order_total
+    dimensions:
+      - had_discount
+      - order_country
+"""
+
+# seeds/base_median_metric_no_time_grain__expected.csv
+base_median_metric_complicated_source__expected_csv = """
+date_month,base_median_metric_complicated_source
+2022-01-01,3.34
+2022-02-01,7.11
+""".lstrip()
+
+class TestBaseMedianMetricComplicatedSource:
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": complicated_median_source_csv,
+            "base_median_metric_complicated_source__expected.csv": base_median_metric_complicated_source__expected_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "base_median_metric_complicated_source.sql": base_median_metric_complicated_source_sql,
+            "base_median_metric_complicated_source.yml": base_median_metric_complicated_source_yml
+        }
+
+    def test_base_median_metric_complicated_source(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # initial run
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        # test tests
+        results = run_dbt(["test"]) # expect passing test
+        assert len(results) == 1
+
+        # # # validate that the results include pass
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ["pass"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Addresses #180 . More discussion over implementation can be found in that issue.

TLDR:
- A `default` , `postgres` and `bigquery` addition to `gen_primary_metric_aggregate` . The BQ one is an any_value aggregation
- The creation of a new macro in `gen_base_query` that now mimics the `gen_primary_metric_aggregate` in its use of dispatch. If the `calculation_method` is median and bigquery then it does the window calc
- An annoying amount of comma logic for the partitioning 😭 

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
- [ ] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
