### PR TITLE
Adding error message for derived metric filters

### DIFF
--- a/.changes/unreleased/Under the Hood-20230130-122730.yaml
+++ b/.changes/unreleased/Under the Hood-20230130-122730.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: validation logic on derived filters
+time: 2023-01-30T12:27:30.231612-06:00
+custom:
+  Author: callum-mcdata
+  Issue: "200"
+  PR: "201"

--- a/integration_tests/models/metric_definitions/base_sum_metric.yml
+++ b/integration_tests/models/metric_definitions/base_sum_metric.yml
@@ -10,8 +10,8 @@ metrics:
     dimensions:
       - had_discount
       - order_country
-    config:
-      restrict_no_time_grain: True
+    # config:
+    #   restrict_no_time_grain: True
 
   - name: base_sum_metric_duplicate
     model: ref('fact_orders_duplicate')

--- a/integration_tests/models/metric_definitions/derived_metric.yml
+++ b/integration_tests/models/metric_definitions/derived_metric.yml
@@ -10,3 +10,8 @@ metrics:
     dimensions:
       - had_discount
       - order_country
+
+    filters:
+      - field: had_discount
+        operator: 'is'
+        value: 'true'

--- a/macros/validation/validate_derived_metrics.sql
+++ b/macros/validation/validate_derived_metrics.sql
@@ -5,6 +5,9 @@
 
     {% for metric_name in metric_tree.full_set %}
         {% set metric_relation = metric(metric_name)%}
+        {% if metric_relation.calculation_method == "derived" and metric_relation.filters | length > 0 %}
+            {%- do exceptions.raise_compiler_error("Derived metrics, such as " ~ metric_relation.name ~", do not support the use of filters. ") %}
+        {%- endif %}
         {% set metric_relation_depends_on = metric_relation.metrics  | join (",") %}
         {% if metric_relation.calculation_method != "derived" and metric_relation.metrics | length > 0 %}
             {%- do exceptions.raise_compiler_error("The metric " ~ metric_relation.name ~" also references '" ~ metric_relation_depends_on ~ "' but its calculation method is '" ~ metric_relation.calculation_method ~ "'. Only metrics of calculation method derived can reference other metrics.") %}

--- a/tests/functional/invalid_configs/test_invalid_derived_metric_filter.py
+++ b/tests/functional/invalid_configs/test_invalid_derived_metric_filter.py
@@ -1,0 +1,104 @@
+from struct import pack
+import os
+import pytest
+from dbt.tests.util import run_dbt
+
+# our file contents
+from tests.functional.fixtures import (
+    fact_orders_source_csv,
+    fact_orders_sql,
+    fact_orders_yml,
+)
+
+# models/invalid_derived_metric.sql
+invalid_derived_metric_sql = """
+select *
+from 
+{{ metrics.calculate(metric('invalid_derived_metric'), 
+    grain='month'
+    )
+}}
+"""
+
+# models/invalid_derived_metric.yml
+invalid_derived_metric_yml = """
+version: 2 
+models:
+  - name: invalid_derived_metric
+
+metrics:
+  - name: base_sum_metric
+    model: ref('fact_orders')
+    label: Order Total ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    calculation_method: sum
+    expression: order_total
+    dimensions:
+      - had_discount
+      - order_country
+
+  - name: invalid_derived_metric
+    label: Total Discount ($)
+    timestamp: order_date
+    time_grains: [day, week, month]
+    calculation_method: derived
+    expression: "{{metric('base_sum_metric')}} - 1"
+    dimensions:
+      - had_discount
+      - order_country
+
+    filters:
+      - field: had_discount
+        operator: 'is'
+        value: 'true'
+"""
+
+class TestInvalidDerivedMetric:
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "example",
+          "models": {"+materialized": "table"}
+        }
+
+    # install current repo as package
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {
+            "packages": [
+                {"local": os.getcwd()}
+                ]
+        }
+
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "fact_orders_source.csv": fact_orders_source_csv
+            }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fact_orders.sql": fact_orders_sql,
+            "fact_orders.yml": fact_orders_yml,
+            "invalid_derived_metric.sql": invalid_derived_metric_sql,
+            "invalid_derived_metric.yml": invalid_derived_metric_yml
+        }
+
+    def test_invalid_derived_metric(self,project,):
+        # running deps to install package
+        results = run_dbt(["deps"])
+
+        # seed seeds
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        # Here we expect the run to fail because the incorrect
+        # config won't allow it to compile
+        run_dbt(["run"], expect_pass = False)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Based on #215 , adding an error message if a derived metric has filters configured.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
