### PR TITLE
Add support for hourly subday grain

### DIFF
--- a/macros/get_metric_sql.sql
+++ b/macros/get_metric_sql.sql
@@ -48,7 +48,8 @@ metrics there are -#}
 {{ metrics.gen_calendar_cte(
     calendar_tbl=calendar_tbl,
     start_date=start_date, 
-    end_date=end_date) 
+    end_date=end_date,
+    grain=grain) 
     }}
 {#- Next we check if it is a composite metric or single metric by checking the length of the list -#}
 {#- This filter forms the basis of how we construct the SQL -#}

--- a/macros/sql_gen/gen_aggregate_cte.sql
+++ b/macros/sql_gen/gen_aggregate_cte.sql
@@ -37,7 +37,11 @@
         {% endfor -%}
 
         {%- if grain %}
-        {{ bool_or('metric_date_day is not null') }} as has_data,
+            {% if grain == 'hour' %}
+            {{ bool_or('metric_date_hour is not null') }} as has_data,
+            {% else %}
+            {{ bool_or('metric_date_day is not null') }} as has_data,
+            {%- endif %}
         {%- endif %}
 
         {#- This line performs the relevant aggregation by calling the 

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -12,7 +12,11 @@
                 the same windows & filters, we can base the conditional off of the first 
                 value in the list because the order doesn't matter. 
             -#}
-            cast(base_model.{{group_values.timestamp}} as date) as metric_date_day,
+            {% if grain == 'hour' %}
+                dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) as metric_date_hour
+            {% else %}
+                cast(base_model.{{group_values.timestamp}} as date) as metric_date_day,
+            {% endif %}
             calendar.date_{{ grain }} as date_{{grain}},
             calendar.date_day as window_filter_date,
                 {%- if secondary_calculations | length > 0 %}
@@ -35,7 +39,7 @@
         from {{ group_values.metric_model }} base_model 
         {# -#}
         {%- if grain or calendar_dimensions|length > 0 -%}
-        {{ metrics.gen_calendar_join(group_values) }} 
+        {{ metrics.gen_calendar_join(group_values, grain) }} 
         {%- endif -%}
         {# #}
         where 1=1

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -13,7 +13,7 @@
                 value in the list because the order doesn't matter. 
             -#}
             {% if grain == 'hour' %}
-                date_trunc('hour', group_values.timestamp) as metric_date_hour,
+                date_trunc('hour', {{group_values.timestamp}}) as metric_date_hour,
             {% else %}
                 cast(base_model.{{group_values.timestamp}} as date) as metric_date_day,
             {% endif %}

--- a/macros/sql_gen/gen_base_query.sql
+++ b/macros/sql_gen/gen_base_query.sql
@@ -13,7 +13,7 @@
                 value in the list because the order doesn't matter. 
             -#}
             {% if grain == 'hour' %}
-                dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) as metric_date_hour
+                date_trunc('hour', group_values.timestamp) as metric_date_hour,
             {% else %}
                 cast(base_model.{{group_values.timestamp}} as date) as metric_date_day,
             {% endif %}

--- a/macros/sql_gen/gen_calendar_cte.sql
+++ b/macros/sql_gen/gen_calendar_cte.sql
@@ -1,15 +1,48 @@
-{%- macro gen_calendar_cte(calendar_tbl, start_date, end_date) -%}
-    {{ return(adapter.dispatch('gen_calendar_cte', 'metrics')(calendar_tbl, start_date, end_date)) }}
+{%- macro gen_calendar_cte(calendar_tbl, start_date, end_date, grain) -%}
+    {{ return(adapter.dispatch('gen_calendar_cte', 'metrics')(calendar_tbl, start_date, end_date, grain)) }}
 {%- endmacro -%}
 
-{%- macro default__gen_calendar_cte(calendar_tbl, start_date, end_date) %}
+{%- macro default__gen_calendar_cte(calendar_tbl, start_date, end_date, grain) %}
 
 with calendar as (
     {# This CTE creates our base calendar and then limits the date range for the 
     start and end date provided by the macro call -#}
     select 
-        * 
-    from {{ calendar_tbl }}
+    {% if grain == 'hour' %}
+        to_timestamp_ntz(concat(date_day, ' ', date_hour), 'YYYY-MM-DD HH24') as date_hour,
+    {% endif %}
+        c.* 
+    from {{ calendar_tbl }} c
+    {% if grain == 'hour' %}
+        cross join
+        (
+        values
+            ('00'),
+            ('01'),
+            ('02'),
+            ('03'),
+            ('04'),
+            ('05'),
+            ('06'),
+            ('07'),
+            ('08'),
+            ('09'),
+            ('10'),
+            ('11'),
+            ('12'),
+            ('13'),
+            ('14'),
+            ('15'),
+            ('16'),
+            ('17'),
+            ('18'),
+            ('19'),
+            ('20'),
+            ('21'),
+            ('22'),
+            ('23')
+    ) hours(date_hour)
+    {% endif %}
     {% if start_date or end_date %}
         {%- if start_date and end_date -%}
             where date_day >= cast('{{ start_date }}' as date)

--- a/macros/sql_gen/gen_calendar_cte.sql
+++ b/macros/sql_gen/gen_calendar_cte.sql
@@ -9,7 +9,7 @@ with calendar as (
     start and end date provided by the macro call -#}
     select 
     {% if grain == 'hour' %}
-        to_timestamp_ntz(concat(date_day, ' ', date_hour), 'YYYY-MM-DD HH24') as date_hour,
+        to_timestamp_ntz(concat(date_day, ' ', hour), 'YYYY-MM-DD HH24') as date_hour,
     {% endif %}
         c.* 
     from {{ calendar_tbl }} c
@@ -41,7 +41,7 @@ with calendar as (
             ('21'),
             ('22'),
             ('23')
-    ) hours(date_hour)
+    ) hours(hour)
     {% endif %}
     {% if start_date or end_date %}
         {%- if start_date and end_date -%}

--- a/macros/sql_gen/gen_calendar_join.sql
+++ b/macros/sql_gen/gen_calendar_join.sql
@@ -8,7 +8,7 @@
             on cast(base_model.{{group_values.timestamp}} as date) > dateadd({{group_values.window.period}}, -{{group_values.window.count}}, calendar.date_day)
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' -%}
-            on dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) = calendar.date_hour
+            on date_trunc('hour', group_values.timestamp) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
         {% endif -%}

--- a/macros/sql_gen/gen_calendar_join.sql
+++ b/macros/sql_gen/gen_calendar_join.sql
@@ -8,7 +8,7 @@
             on cast(base_model.{{group_values.timestamp}} as date) > dateadd({{group_values.window.period}}, -{{group_values.window.count}}, calendar.date_day)
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' %}
-            on date_trunc('hour', group_values.timestamp) = calendar.date_hour
+            on date_trunc('hour', {{group_values.timestamp}}) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
         {% endif -%}

--- a/macros/sql_gen/gen_calendar_join.sql
+++ b/macros/sql_gen/gen_calendar_join.sql
@@ -7,7 +7,7 @@
         {%- if group_values.window is not none and grain != 'hour' %}
             on cast(base_model.{{group_values.timestamp}} as date) > dateadd({{group_values.window.period}}, -{{group_values.window.count}}, calendar.date_day)
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
-        {%- elif grain == 'hour' -%}
+        {%- elif grain == 'hour' %}
             on date_trunc('hour', group_values.timestamp) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
@@ -16,7 +16,7 @@
 
 {% macro bigquery__gen_calendar_join(group_values, grain) %}
         left join calendar
-        {%- if group_values.window is not none %}
+        {%- if group_values.window is not none and grain != 'hour' %}
             on cast(base_model.{{group_values.timestamp}} as date) > date_sub(calendar.date_day, interval {{group_values.window.count}} {{group_values.window.period}})
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' -%}
@@ -28,7 +28,7 @@
 
 {% macro postgres__gen_calendar_join(group_values, grain) %}
         left join calendar
-        {%- if group_values.window is not none %}
+        {%- if group_values.window is not none and grain != 'hour' %}
             on cast(base_model.{{group_values.timestamp}} as date) > calendar.date_day - interval '{{group_values.window.count}} {{group_values.window.period}}'
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' -%}
@@ -40,7 +40,7 @@
 
 {% macro redshift__gen_calendar_join(group_values, grain) %}
         left join calendar
-        {%- if group_values.window is not none %}
+        {%- if group_values.window is not none and grain != 'hour' %}
             on cast(base_model.{{group_values.timestamp}} as date) > dateadd({{group_values.window.period}}, -{{group_values.window.count}}, calendar.date_day)
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
        {%- elif grain == 'hour' -%}

--- a/macros/sql_gen/gen_calendar_join.sql
+++ b/macros/sql_gen/gen_calendar_join.sql
@@ -20,7 +20,7 @@
             on cast(base_model.{{group_values.timestamp}} as date) > date_sub(calendar.date_day, interval {{group_values.window.count}} {{group_values.window.period}})
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' -%}
-            on dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) = calendar.date_hour
+            on date_trunc('hour', {{group_values.timestamp}}) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
         {% endif -%}
@@ -32,7 +32,7 @@
             on cast(base_model.{{group_values.timestamp}} as date) > calendar.date_day - interval '{{group_values.window.count}} {{group_values.window.period}}'
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
         {%- elif grain == 'hour' -%}
-            on dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) = calendar.date_hour
+            on date_trunc('hour', {{group_values.timestamp}}) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
         {% endif -%}
@@ -44,7 +44,7 @@
             on cast(base_model.{{group_values.timestamp}} as date) > dateadd({{group_values.window.period}}, -{{group_values.window.count}}, calendar.date_day)
             and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
        {%- elif grain == 'hour' -%}
-            on dateadd(HOUR, datediff(HOUR, 0, base_model.{{group_values.timestamp}}), 0) = calendar.date_hour
+            on date_trunc('hour', {{group_values.timestamp}}) = calendar.date_hour
         {%- else %}
             on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
         {% endif -%}

--- a/macros/variables/get_grain_order.sql
+++ b/macros/variables/get_grain_order.sql
@@ -3,5 +3,5 @@
 {% endmacro %}
 
 {% macro default__get_grain_order() %}
-    {% do return (['day', 'week', 'month', 'quarter', 'year']) %}
+    {% do return (['hour', 'day', 'week', 'month', 'quarter', 'year']) %}
 {% endmacro %}


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

This adds support for the `hourly` sub day grain by dynamically expanding the column CTE to include `date_hour`.

This PR is inspired by the discussion here: https://github.com/dbt-labs/dbt_metrics/issues/166
## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
