### PR TITLE
Issue 236: Fix metrics develop macro replacement

### DIFF
--- a/macros/variables/get_metric_definition.sql
+++ b/macros/variables/get_metric_definition.sql
@@ -18,7 +18,7 @@
     {# Behavior specific to develop #}
     {% if metric_definition is mapping %}
         {# We need to do some cleanup for metric parsing #}
-        {% set metric_expression = metric_definition.expression | replace("metric(","") | replace(")","") | replace("{{","") | replace("}}","")  | replace("'","") | replace('"',"")  %}
+        {% set metric_expression = metric_definition.expression | replace(" ","") | replace("{{metric('","") | replace("')}}","")  | replace("'","") | replace('"',"")  %}
         {% do metrics_dictionary_dict.update({'expression': metric_expression})%} 
         {% if metric_definition.window %}
             {% do metrics_dictionary_dict.update({'window': metric_definition.window}) %}


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This PR solves the issue detected with derived metrics when working with the `metrics.develop` macro. Specifically, it was detected that derived metrics with parenthesis on the expression (for example, `expression: metric_1/(0.9*metric_2)`) could not be calculated adequately. The problem was clearly described in this [issue](https://github.com/dbt-labs/dbt_metrics/issues/236). 

The unique change that I propose is to modify the current line 21 of the file `macros\variables\get_metric_definition.sql` which tries to replace `{{metric`, `}}` and `)` (among others) from the expression of derived metrics when working with `metrics.develop` macro.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
    - [ ] Databricks
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
