### PR TITLE
Moving dbt-expectations from Calogica to Metaplane

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,10 @@
 ## Contributors:
 --->
 
+# Unreleased
+
+* Moving dbt-expectations from Calogica to Metaplane n [#256](https://github.com/dbt-labs/dbt_metrics/pull/256)
+
 # dbt_metrics v0.1.5
 ## What's Changed
 * start_date and end_date casting fix by @fivetran-joemarkiewicz in [#22](https://github.com/dbt-labs/dbt_metrics/pull/22)

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,4 +1,4 @@
 packages:
   - local: ../
-  - package: calogica/dbt_expectations
+  - package: metaplane/dbt_expectations
     version: [">=0.6.0", "<0.7.0"]


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->
Calogica's [dbt-expectation](https://github.com/calogica/dbt-expectations) package is no longer supported. Instead, Metaplane's [dbt-expectations](https://github.com/metaplane/dbt-expectations) package is now featured on the [dbt Package Hub](https://hub.getdbt.com/metaplane/dbt_expectations/latest/). This PR migrates the dependency in this repo.

## ChecklistCalogica's dbt-expectation package is no longer supported. Instead, Metaplane's dbt-expectations package is now featured on the dbt Package Hub. This PR migrates the dependency in this repo.
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

---
### Tenets to keep in mind 
- A metric value should be consistent everywhere that it is referenced
- We prefer generalized metrics with many dimensions over specific metrics with few dimensions
- It should be easier to use dbt’s metrics than it is to avoid them
- Organization and discoverability are as important as precision
- One-off models built to power metrics are an anti-pattern
